### PR TITLE
Link to contract source from imports

### DIFF
--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -22,9 +22,9 @@
     import { ContractBuilder, buildGeneric, printContract, printContractVersioned, sanitizeKind, OptionsError } from '@openzeppelin/wizard';
     import { postConfig } from './post-config';
     import { remixURL } from './remix';
-    import { version as contractsVersion } from "@openzeppelin/contracts/package.json";
 
     import { saveAs } from 'file-saver';
+    import { injectHyperlinks } from './utils/inject-hyperlinks';
 
     const dispatch = createEventDispatcher();
 
@@ -58,21 +58,6 @@
 
     $: code = printContract(contract);
     $: highlightedCode = injectHyperlinks(hljs.highlight('solidity', code).value);
-
-    function injectHyperlinks(code: string) {
-      const importRegex = /(@openzeppelin\/)(contracts-upgradeable\/|contracts\/)(.*)(&quot;)/gm // we are modifying HTML, so use HTML escaped chars
-      let result = code;
-      let match = importRegex.exec(code);
-      while (match != null) {
-        const [line, ozPrefix, contractsLibrary, relativePath, quotes] = match;
-        if (line !== undefined && ozPrefix !== undefined && contractsLibrary !== undefined && relativePath !== undefined && quotes !== undefined) {
-          const replacedImportLine = `<a href='https://github.com/OpenZeppelin/openzeppelin-${contractsLibrary}blob/v${contractsVersion}/contracts/${relativePath}' target='_blank' rel='noopener noreferrer' style='color: inherit'>${ozPrefix}${contractsLibrary}${relativePath}</a>${quotes}`;
-          result = result.replace(line, replacedImportLine);
-        }
-        match = importRegex.exec(code);
-      }
-      return result;
-    }
 
     const copyHandler = async () => {
       await navigator.clipboard.writeText(code);

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -59,7 +59,7 @@
     $: highlightedCode = injectHyperlinks(hljs.highlight('solidity', code).value);
 
     function injectHyperlinks(code: string) {
-      const importRegex = /(@openzeppelin\/)(contracts-upgradeable|contracts)(\/.*)(&quot;)/gm // we are modifying HTML, so use HTML escaped chars
+      const importRegex = /(@openzeppelin\/)(contracts-upgradeable\/|contracts\/)(.*)(&quot;)/gm // we are modifying HTML, so use HTML escaped chars
       let result = code;
       let match = importRegex.exec(code);
       while (match != null) {
@@ -69,7 +69,7 @@
         const relativePath = match[3];
         const quotes = match[4];
         if (line !== undefined && ozPrefix !== undefined && contractsLibrary !== undefined && relativePath !== undefined && quotes !== undefined) {
-          const replacedImportLine = '<a href=\'https://github.com/OpenZeppelin/openzeppelin-' + contractsLibrary + '/blob/master/contracts' + relativePath + '\' target=\'blank\' style=\'color: inherit\'>' + ozPrefix + contractsLibrary + relativePath + '</a>' + quotes;
+          const replacedImportLine = `<a href='https://github.com/OpenZeppelin/openzeppelin-${contractsLibrary}blob/master/contracts/${relativePath}' target='_blank' rel='noopener noreferrer' style='color: inherit'>${ozPrefix}${contractsLibrary}${relativePath}</a>${quotes}`;
           result = result.replace(line, replacedImportLine);
         }
         match = importRegex.exec(code);

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -69,7 +69,7 @@
         const relativePath = match[3];
         const quotes = match[4];
         if (line !== undefined && ozPrefix !== undefined && contractsLibrary !== undefined && relativePath !== undefined && quotes !== undefined) {
-          const replacedImportLine = '<a href=\'https://github.com/OpenZeppelin/openzeppelin-' + contractsLibrary + '/blob/master/contracts' + relativePath + '\' target=\'blank\'>' + ozPrefix + contractsLibrary + relativePath + '</a>' + quotes;
+          const replacedImportLine = '<a href=\'https://github.com/OpenZeppelin/openzeppelin-' + contractsLibrary + '/blob/master/contracts' + relativePath + '\' target=\'blank\' style=\'color: #98c379\'>' + ozPrefix + contractsLibrary + relativePath + '</a>' + quotes;
           result = result.replace(line, replacedImportLine);
         }
         match = importRegex.exec(code);

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -56,7 +56,26 @@
     }
 
     $: code = printContract(contract);
-    $: highlightedCode = hljs.highlight('solidity', code).value;
+    $: highlightedCode = injectHyperlinks(hljs.highlight('solidity', code).value);
+
+    function injectHyperlinks(code: string) {
+      const importRegex = /(@openzeppelin\/)(contracts-upgradeable|contracts)(\/.*)(&quot;)/gm // we are modifying HTML, so use HTML escaped chars
+      let result = code;
+      let match = importRegex.exec(code);
+      while (match != null) {
+        const line = match[0];
+        const ozPrefix = match[1];
+        const contractsLibrary = match[2];
+        const relativePath = match[3];
+        const quotes = match[4];
+        if (line !== undefined && ozPrefix !== undefined && contractsLibrary !== undefined && relativePath !== undefined && quotes !== undefined) {
+          const replacedImportLine = '<a href=\'https://github.com/OpenZeppelin/openzeppelin-' + contractsLibrary + '/blob/master/contracts' + relativePath + '\' target=\'blank\'>' + ozPrefix + contractsLibrary + relativePath + '</a>' + quotes;
+          result = result.replace(line, replacedImportLine);
+        }
+        match = importRegex.exec(code);
+      }
+      return result;
+    }
 
     const copyHandler = async () => {
       await navigator.clipboard.writeText(code);

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -69,7 +69,7 @@
         const relativePath = match[3];
         const quotes = match[4];
         if (line !== undefined && ozPrefix !== undefined && contractsLibrary !== undefined && relativePath !== undefined && quotes !== undefined) {
-          const replacedImportLine = '<a href=\'https://github.com/OpenZeppelin/openzeppelin-' + contractsLibrary + '/blob/master/contracts' + relativePath + '\' target=\'blank\' style=\'color: #98c379\'>' + ozPrefix + contractsLibrary + relativePath + '</a>' + quotes;
+          const replacedImportLine = '<a href=\'https://github.com/OpenZeppelin/openzeppelin-' + contractsLibrary + '/blob/master/contracts' + relativePath + '\' target=\'blank\' style=\'color: inherit\'>' + ozPrefix + contractsLibrary + relativePath + '</a>' + quotes;
           result = result.replace(line, replacedImportLine);
         }
         match = importRegex.exec(code);

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -64,11 +64,7 @@
       let result = code;
       let match = importRegex.exec(code);
       while (match != null) {
-        const line = match[0];
-        const ozPrefix = match[1];
-        const contractsLibrary = match[2];
-        const relativePath = match[3];
-        const quotes = match[4];
+        const [line, ozPrefix, contractsLibrary, relativePath, quotes] = match;
         if (line !== undefined && ozPrefix !== undefined && contractsLibrary !== undefined && relativePath !== undefined && quotes !== undefined) {
           const replacedImportLine = `<a href='https://github.com/OpenZeppelin/openzeppelin-${contractsLibrary}blob/v${contractsVersion}/contracts/${relativePath}' target='_blank' rel='noopener noreferrer' style='color: inherit'>${ozPrefix}${contractsLibrary}${relativePath}</a>${quotes}`;
           result = result.replace(line, replacedImportLine);

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -22,6 +22,7 @@
     import { ContractBuilder, buildGeneric, printContract, printContractVersioned, sanitizeKind, OptionsError } from '@openzeppelin/wizard';
     import { postConfig } from './post-config';
     import { remixURL } from './remix';
+    import { version as contractsVersion } from "@openzeppelin/contracts/package.json";
 
     import { saveAs } from 'file-saver';
 
@@ -69,7 +70,7 @@
         const relativePath = match[3];
         const quotes = match[4];
         if (line !== undefined && ozPrefix !== undefined && contractsLibrary !== undefined && relativePath !== undefined && quotes !== undefined) {
-          const replacedImportLine = `<a href='https://github.com/OpenZeppelin/openzeppelin-${contractsLibrary}blob/master/contracts/${relativePath}' target='_blank' rel='noopener noreferrer' style='color: inherit'>${ozPrefix}${contractsLibrary}${relativePath}</a>${quotes}`;
+          const replacedImportLine = `<a href='https://github.com/OpenZeppelin/openzeppelin-${contractsLibrary}blob/v${contractsVersion}/contracts/${relativePath}' target='_blank' rel='noopener noreferrer' style='color: inherit'>${ozPrefix}${contractsLibrary}${relativePath}</a>${quotes}`;
           result = result.replace(line, replacedImportLine);
         }
         match = importRegex.exec(code);

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -129,3 +129,7 @@ input.input-inline {
 .has-error {
   box-shadow: 0 0 var(--size-1) var(--red-2);
 }
+
+.import-link {
+  color: inherit;
+}

--- a/packages/ui/src/styles/reset.css
+++ b/packages/ui/src/styles/reset.css
@@ -19,12 +19,3 @@ button, input, select, textarea {
   font-size: inherit;
   color: inherit;
 }
-
-a:link,
-a:visited {
-  color: inherit;
-}
-
-a:hover {
-  color: var(--blue-2);
-}

--- a/packages/ui/src/styles/reset.css
+++ b/packages/ui/src/styles/reset.css
@@ -19,3 +19,12 @@ button, input, select, textarea {
   font-size: inherit;
   color: inherit;
 }
+
+a:link,
+a:visited {
+  color: inherit;
+}
+
+a:hover {
+  color: var(--blue-2);
+}

--- a/packages/ui/src/utils/inject-hyperlinks.ts
+++ b/packages/ui/src/utils/inject-hyperlinks.ts
@@ -1,0 +1,6 @@
+import { version as contractsVersion } from "@openzeppelin/contracts/package.json";
+
+export function injectHyperlinks(code: string) {
+  const importRegex = /(@openzeppelin\/)(contracts-upgradeable\/|contracts\/)(.*)(&quot;)/g // we are modifying HTML, so use HTML escaped chars
+  return code.replace(importRegex, `<a href='https://github.com/OpenZeppelin/openzeppelin-$2blob/v${contractsVersion}/contracts/$3' target='_blank' rel='noopener noreferrer'>$1$2$3</a>$4`);
+}

--- a/packages/ui/src/utils/inject-hyperlinks.ts
+++ b/packages/ui/src/utils/inject-hyperlinks.ts
@@ -2,5 +2,5 @@ import { version as contractsVersion } from "@openzeppelin/contracts/package.jso
 
 export function injectHyperlinks(code: string) {
   const importRegex = /(@openzeppelin\/)(contracts-upgradeable\/|contracts\/)(.*)(&quot;)/g // we are modifying HTML, so use HTML escaped chars
-  return code.replace(importRegex, `<a href='https://github.com/OpenZeppelin/openzeppelin-$2blob/v${contractsVersion}/contracts/$3' target='_blank' rel='noopener noreferrer'>$1$2$3</a>$4`);
+  return code.replace(importRegex, `<a class="import-link" href="https://github.com/OpenZeppelin/openzeppelin-$2blob/v${contractsVersion}/contracts/$3" target="_blank" rel="noopener noreferrer">$1$2$3</a>$4`);
 }


### PR DESCRIPTION
Turns import statements into hyperlinks to the corresponding contract source code on GitHub.

Links to source code rather than docs site for the following reasons:
- Import text should be the hyperlink itself, so only one set of links can be provided (either source or docs but not both)
- Developers using a parent contract may want to see how it was written, so are probably interested in the source
- Each feature's tooltip already has a Read More link that goes to the docs
- If Upgradeability is enabled, the links point to source in [contracts-upgradable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/) so developers can see the initializer functions