### PR TITLE
Update links to Pausable

### DIFF
--- a/packages/ui/src/ERC1155Controls.svelte
+++ b/packages/ui/src/ERC1155Controls.svelte
@@ -66,7 +66,7 @@
     <label class:checked={opts.pausable}>
       <input type="checkbox" bind:checked={opts.pausable}>
       Pausable
-      <HelpTooltip link="https://docs.openzeppelin.com/contracts/4.x/api/utils#Pausable">
+      <HelpTooltip link="https://docs.openzeppelin.com/contracts/4.x/api/security#Pausable">
         Privileged accounts will be able to pause the functionality marked as <code>whenNotPaused</code>.
         Useful for emergency response.
       </HelpTooltip>

--- a/packages/ui/src/ERC20Controls.svelte
+++ b/packages/ui/src/ERC20Controls.svelte
@@ -73,7 +73,7 @@
     <label class:checked={opts.pausable}>
       <input type="checkbox" bind:checked={opts.pausable}>
       Pausable
-      <HelpTooltip link="https://docs.openzeppelin.com/contracts/4.x/api/utils#Pausable">
+      <HelpTooltip link="https://docs.openzeppelin.com/contracts/4.x/api/security#Pausable">
         Privileged accounts will be able to pause the functionality marked as <code>whenNotPaused</code>.
         Useful for emergency response.
       </HelpTooltip>

--- a/packages/ui/src/ERC721Controls.svelte
+++ b/packages/ui/src/ERC721Controls.svelte
@@ -93,7 +93,7 @@
     <label class:checked={opts.pausable}>
       <input type="checkbox" bind:checked={opts.pausable}>
       Pausable
-      <HelpTooltip link="https://docs.openzeppelin.com/contracts/4.x/api/utils#Pausable">
+      <HelpTooltip link="https://docs.openzeppelin.com/contracts/4.x/api/security#Pausable">
         Privileged accounts will be able to pause the functionality marked as <code>whenNotPaused</code>.
         Useful for emergency response.
       </HelpTooltip>


### PR DESCRIPTION
Links to Pausable are currently pointing to https://docs.openzeppelin.com/contracts/4.x/api/utils#Pausable, which appears to have been moved to https://docs.openzeppelin.com/contracts/4.x/api/security#Pausable.

This PR updates those links.