### PR TITLE
Add getInitialSupply API for Cairo

### DIFF
--- a/packages/core-cairo/README.md
+++ b/packages/core-cairo/README.md
@@ -35,3 +35,15 @@ The default options that are used for [`printERC20`](#printerc20).
 const erc721defaults: Required<ERC721Options>
 ```
 The default options that are used for [`printERC721`](#printerc721).
+
+### Utils
+
+#### `getInitialSupply`
+
+Calculates the initial supply that would be used in an ERC20 contract based on a given premint amount and number of decimals.
+
+- `premint` Premint amount in token units, may be fractional
+- `decimals` The number of decimals in the token
+
+Returns `premint` with zeros padded or removed based on `decimals`.
+Throws an error if `premint` has more than one decimal character or is more precise than allowed by the `decimals` argument.

--- a/packages/core-cairo/src/erc20.ts
+++ b/packages/core-cairo/src/erc20.ts
@@ -151,7 +151,7 @@ function addPremint(c: ContractBuilder, amount: string, decimals: string) {
       });
     } 
 
-    const premintAbsolute = getPremintAbsolute(amount, parseInt(decimals));
+    const premintAbsolute = getInitialSupply(amount, parseInt(decimals));
     const premintBN = new BN(premintAbsolute, 10);
     if (premintBN.bitLength() > 256) { // 256 bits
       throw new OptionsError({
@@ -174,14 +174,14 @@ function addPremint(c: ContractBuilder, amount: string, decimals: string) {
 }
 
 /**
- * Gets premint amount, taking the decimals field into consideration.
+ * Calculates the initial supply that would be used in an ERC20 contract based on a given premint amount and number of decimals.
  * 
  * @param premint Premint amount in token units, may be fractional
  * @param decimals The number of decimals in the token
- * @returns premint with zeros padded or removed
- * @throws OptionsError if premint has more than one decimal character or is more precise than allowed by the decimals field
+ * @returns `premint` with zeros padded or removed based on `decimals`.
+ * @throws OptionsError if `premint` has more than one decimal character or is more precise than allowed by the `decimals` argument.
  */
-function getPremintAbsolute(premint: string, decimals: number): string {
+export function getInitialSupply(premint: string, decimals: number): string {
   let result;
   const premintSegments = premint.split(".");
   if (premintSegments.length > 2) {
@@ -213,7 +213,6 @@ function getPremintAbsolute(premint: string, decimals: number): string {
   }
   return result;
 }
-
 
 function addMintable(c: ContractBuilder, access: Access) {
   setAccessControl(c, functions.mint, access);

--- a/packages/core-cairo/src/index.ts
+++ b/packages/core-cairo/src/index.ts
@@ -10,7 +10,7 @@ export type { Access } from './set-access-control';
 export type { Upgradeable } from './set-upgradeable';
 export type { Info } from './set-info';
 
-export { premintPattern, defaults as erc20defaults, printERC20 } from './erc20';
+export { premintPattern, defaults as erc20defaults, printERC20, getInitialSupply } from './erc20';
 export { defaults as erc721defaults, printERC721 } from './erc721';
 
 export { defaults as infoDefaults } from './set-info';


### PR DESCRIPTION
After using the Wizard API to generate a contract, users may want to generate test cases to ensure their contracts behave (and continue to behave) as expected.  

This may include checking the initial supply of ERC20 tokens.  Provide a helper function to calculate the initial supply based on the user-specified premint amount and number of decimals.

Needed for https://github.com/onlydustxyz/generator-starknet/issues/30

Depends on https://github.com/OpenZeppelin/contracts-wizard/pull/136 for new API format.