### PR TITLE
Cairo - Add UUPS radio button

### DIFF
--- a/packages/ui/src/cairo/UpgradeabilitySection.svelte
+++ b/packages/ui/src/cairo/UpgradeabilitySection.svelte
@@ -2,18 +2,12 @@
   import type { Upgradeable } from '@openzeppelin/wizard-cairo';
 
   import HelpTooltip from '../HelpTooltip.svelte';
+  import ToggleRadio from '../inputs/ToggleRadio.svelte';
 
   export let upgradeable: Upgradeable;
 
-  // Syncs UUPS radio button with Upgradeability checkbox
-  let proxyKind: false | 'uups';
-  $: {
-    proxyKind = upgradeable ? 'uups' : false;
-  }
-
-  function enableUpgradability() {
-    upgradeable = true;
-  }
+  let upgradeableWithKind: 'uups' | false;
+  $: upgradeable = upgradeableWithKind === 'uups' ? true : false;
 </script>
 
 <section class="controls-section">
@@ -22,7 +16,7 @@
     <label class="flex items-center tooltip-container pr-2">
       <span>Upgradeability</span>
       <span class="ml-1">
-        <input type="checkbox" bind:checked={upgradeable}>
+        <ToggleRadio bind:value={upgradeableWithKind} defaultValue='uups' />
       </span>
       <HelpTooltip align="right" link="https://github.com/OpenZeppelin/cairo-contracts/blob/main/docs/Proxies.md">
       Smart contracts are immutable by default unless deployed behind an upgradeable proxy.
@@ -31,8 +25,8 @@
   </h1>
 
   <div class="checkbox-group">
-    <label class:checked={upgradeable === true}>
-      <input type="radio" bind:group={proxyKind} value='uups' on:change={enableUpgradability}>
+    <label class:checked={upgradeableWithKind === 'uups'}>
+      <input type="radio" bind:group={upgradeableWithKind} value='uups'>
       UUPS
       <HelpTooltip link="https://github.com/OpenZeppelin/cairo-contracts/blob/main/docs/Proxies.md#proxy-contract">
       Requires including code in your contract for upgrades. Allows flexibility for authorizing upgrades.

--- a/packages/ui/src/cairo/UpgradeabilitySection.svelte
+++ b/packages/ui/src/cairo/UpgradeabilitySection.svelte
@@ -4,6 +4,16 @@
   import HelpTooltip from '../HelpTooltip.svelte';
 
   export let upgradeable: Upgradeable;
+
+  // Syncs UUPS radio button with Upgradeability checkbox
+  let proxyKind: false | 'uups';
+  $: {
+    proxyKind = upgradeable ? 'uups' : false;
+  }
+
+  function enableUpgradability() {
+    upgradeable = true;
+  }
 </script>
 
 <section class="controls-section">
@@ -14,10 +24,20 @@
       <span class="ml-1">
         <input type="checkbox" bind:checked={upgradeable}>
       </span>
-      <HelpTooltip align="right" link="https://github.com/OpenZeppelin/cairo-contracts/blob/main/docs/Proxies.md#using-proxies">
+      <HelpTooltip align="right" link="https://github.com/OpenZeppelin/cairo-contracts/blob/main/docs/Proxies.md">
       Smart contracts are immutable by default unless deployed behind an upgradeable proxy.
       </HelpTooltip>
     </label>
   </h1>
+
+  <div class="checkbox-group">
+    <label class:checked={upgradeable === true}>
+      <input type="radio" bind:group={proxyKind} value='uups' on:change={enableUpgradability}>
+      UUPS
+      <HelpTooltip link="https://github.com/OpenZeppelin/cairo-contracts/blob/main/docs/Proxies.md#proxy-contract">
+      Requires including code in your contract for upgrades. Allows flexibility for authorizing upgrades.
+      </HelpTooltip>
+    </label>
+  </div>
 </section>
 

--- a/packages/ui/src/cairo/UpgradeabilitySection.svelte
+++ b/packages/ui/src/cairo/UpgradeabilitySection.svelte
@@ -5,9 +5,6 @@
   import ToggleRadio from '../inputs/ToggleRadio.svelte';
 
   export let upgradeable: Upgradeable;
-
-  let upgradeableWithKind: 'uups' | false;
-  $: upgradeable = upgradeableWithKind === 'uups' ? true : false;
 </script>
 
 <section class="controls-section">
@@ -16,7 +13,7 @@
     <label class="flex items-center tooltip-container pr-2">
       <span>Upgradeability</span>
       <span class="ml-1">
-        <ToggleRadio bind:value={upgradeableWithKind} defaultValue='uups' />
+        <ToggleRadio bind:value={upgradeable} defaultValue={true} />
       </span>
       <HelpTooltip align="right" link="https://github.com/OpenZeppelin/cairo-contracts/blob/main/docs/Proxies.md">
       Smart contracts are immutable by default unless deployed behind an upgradeable proxy.
@@ -25,8 +22,8 @@
   </h1>
 
   <div class="checkbox-group">
-    <label class:checked={upgradeableWithKind === 'uups'}>
-      <input type="radio" bind:group={upgradeableWithKind} value='uups'>
+    <label class:checked={upgradeable}>
+      <input type="radio" bind:group={upgradeable} value={true}>
       UUPS
       <HelpTooltip link="https://github.com/OpenZeppelin/cairo-contracts/blob/main/docs/Proxies.md#proxy-contract">
       Requires including code in your contract for upgrades. Allows flexibility for authorizing upgrades.

--- a/packages/ui/src/inputs/ToggleRadio.svelte
+++ b/packages/ui/src/inputs/ToggleRadio.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  export let value: false | string = false;
+  type T = $$Generic;
+
+  export let value: false | T = false;
   export let enabled = value !== false;
-  export let defaultValue: string;
+  export let defaultValue: T;
 
   let wasEnabled = enabled;
   let wasValue = value || defaultValue;


### PR DESCRIPTION
Under Upgradeability section, add a UUPS radio button as the only option.

This affects the UI only.  The API for `upgradeable` option will remain as `false | true` to remain backward compatible.