### PR TITLE
Add npm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # [OpenZeppelin Contracts Wizard](https://wizard.openzeppelin.com)
 
+[![Solidity NPM Package](https://img.shields.io/npm/v/@openzeppelin/wizard?color=%234e5de4&label=%40openzeppelin%2Fwizard)](https://www.npmjs.com/package/@openzeppelin/wizard)
+[![Cairo NPM Package](https://img.shields.io/npm/v/@openzeppelin/wizard-cairo?color=%23e55233&label=%40openzeppelin%2Fwizard-cairo)](https://www.npmjs.com/package/@openzeppelin/wizard-cairo)
+
 Contracts Wizard is a web application to interactively build a contract out of components from OpenZeppelin Contracts. Select the kind of contract that you want, set your parameters and desired features, and the Wizard will generate all of the code necessary. The resulting code is ready to be compiled and deployed, or it can serve as a starting point and customized further with application specific logic.
 
 ![](./screenshot.png)

--- a/packages/core-cairo/README.md
+++ b/packages/core-cairo/README.md
@@ -1,5 +1,7 @@
 # OpenZeppelin Contracts Wizard for Cairo
 
+[![NPM Package](https://img.shields.io/npm/v/@openzeppelin/wizard-cairo?color=%23e55233)](https://www.npmjs.com/package/@openzeppelin/wizard-cairo)
+
 Interactively build a contract out of components from OpenZeppelin Contracts for Cairo. Provide parameters and desired features for the kind of contract that you want, and the Wizard will generate all of the code necessary. The resulting code is ready to be compiled and deployed, or it can serve as a starting point and customized further with application specific logic.
 
 This package provides a programmatic API. For a web interface, see https://wizard.openzeppelin.com/cairo

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,7 @@
 # OpenZeppelin Contracts Wizard for Solidity
 
+[![NPM Package](https://img.shields.io/npm/v/@openzeppelin/wizard?color=%234e5de4)](https://www.npmjs.com/package/@openzeppelin/wizard)
+
 Interactively build a contract out of components from OpenZeppelin Contracts. Provide parameters and desired features for the kind of contract that you want, and the Wizard will generate all of the code necessary. The resulting code is ready to be compiled and deployed, or it can serve as a starting point and customized further with application specific logic.
 
 This package provides a programmatic API. For a web interface, see https://wizard.openzeppelin.com


### PR DESCRIPTION
Add npm badges for wizard and wizard-cairo

Colors are based on css for the titles [here](https://github.com/OpenZeppelin/contracts-wizard/blob/master/packages/ui/public/standalone.css#L64) and [here](https://github.com/OpenZeppelin/contracts-wizard/blob/master/packages/ui/public/standalone.css#L79)