### PR TITLE
Fix access checkbox when implied by default

### DIFF
--- a/packages/ui/src/AccessControlSection.svelte
+++ b/packages/ui/src/AccessControlSection.svelte
@@ -14,13 +14,11 @@
   $: {
     if (wasRequired && !required) {
       access = wasAccess;
-    } else if (!wasRequired && required) {
-      wasAccess = access;
-      if (access === false) {
-        access = defaultValueWhenEnabled;
-      }
     } else {
       wasAccess = access;
+      if (access === false && required) {
+        access = defaultValueWhenEnabled;
+      }
     }
 
     wasRequired = required;


### PR DESCRIPTION
Fixes #152 

If `access` should be implied (e.g. `required` is true), then set it to be enabled regardless of whether it was previously implied (e.g. regardless of `wasRequired`)