### PR TITLE
Remove Upgradable Contracts Warnings for Remix

### DIFF
--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -73,8 +73,7 @@
       e.preventDefault();
       if ((e.target as Element)?.classList.contains('disabled')) return;
       const versionedCode = printContractVersioned(contract);
-      const upgradeable = !!opts?.upgradeable;
-      window.open(remixURL(versionedCode, upgradeable).toString(), '_blank');
+      window.open(remixURL(versionedCode, !!opts?.upgradeable).toString(), '_blank');
       if (opts) {
         await postConfig(opts, 'remix', language);
       }

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -73,7 +73,8 @@
       e.preventDefault();
       if ((e.target as Element)?.classList.contains('disabled')) return;
       const versionedCode = printContractVersioned(contract);
-      window.open(remixURL(versionedCode).toString(), '_blank');
+      const upgradeable = !!opts?.upgradeable;
+      window.open(remixURL(versionedCode, upgradeable).toString(), '_blank');
       if (opts) {
         await postConfig(opts, 'remix', language);
       }
@@ -128,15 +129,29 @@
         Copy to Clipboard
       </button>
 
-      <Tooltip let:trigger disabled={!opts?.upgradeable} theme="light-red border" interactive hideOnClick={false}>
-        <button use:trigger class="action-button" class:disabled={opts?.upgradeable} on:click={remixHandler}>
+      <Tooltip
+        let:trigger
+        disabled={!(opts?.upgradeable === "transparent")}
+        theme="light-red border"
+        hideOnClick={false}
+        interactive
+      >
+        <button
+          use:trigger
+          class="action-button"
+          class:disabled={opts?.upgradeable === "transparent"}
+          on:click={remixHandler}
+        >
           <RemixIcon />
           Open in Remix
         </button>
         <div slot="content">
-          Upgradeable contracts are not supported on Remix.
-          Use Hardhat or Truffle with <a href="https://docs.openzeppelin.com/upgrades-plugins/" target="_blank">OpenZeppelin Upgrades</a>.
-          <br>
+          Transparent upgradeable contracts are not supported on Remix.
+          Try using Remix with UUPS upgradability or use Hardhat or Truffle with <a
+            href="https://docs.openzeppelin.com/upgrades-plugins/"
+            target="_blank">OpenZeppelin Upgrades</a
+          >.
+          <br />
           <!-- svelte-ignore a11y-invalid-attribute -->
           <a href="#" on:click={remixHandler}>Open in Remix anyway</a>.
         </div>

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -146,10 +146,8 @@
         </button>
         <div slot="content">
           Transparent upgradeable contracts are not supported on Remix.
-          Try using Remix with UUPS upgradability or use Hardhat or Truffle with <a
-            href="https://docs.openzeppelin.com/upgrades-plugins/"
-            target="_blank">OpenZeppelin Upgrades</a
-          >.
+          Try using Remix with UUPS upgradability or use Hardhat or Truffle with
+          <a href="https://docs.openzeppelin.com/upgrades-plugins/" target="_blank">OpenZeppelin Upgrades</a>.
           <br />
           <!-- svelte-ignore a11y-invalid-attribute -->
           <a href="#" on:click={remixHandler}>Open in Remix anyway</a>.

--- a/packages/ui/src/remix.ts
+++ b/packages/ui/src/remix.ts
@@ -1,8 +1,8 @@
-export function remixURL(code: string, upgradable = false): URL {
+export function remixURL(code: string, upgradeable = false): URL {
   const remix = new URL('https://remix.ethereum.org');
   remix.searchParams.set('code', btoa(code).replace(/=*$/, ''));
-  if (upgradable) {
-    remix.searchParams.set('deployProxy', upgradable.toString());
+  if (upgradeable) {
+    remix.searchParams.set('deployProxy', upgradeable.toString());
   }
   return remix;
 }

--- a/packages/ui/src/remix.ts
+++ b/packages/ui/src/remix.ts
@@ -1,5 +1,8 @@
-export function remixURL(code: string): URL {
+export function remixURL(code: string, upgradable = false): URL {
   const remix = new URL('https://remix.ethereum.org');
   remix.searchParams.set('code', btoa(code).replace(/=*$/, ''));
+  if (upgradable) {
+    remix.searchParams.set('deployProxy', upgradable.toString());
+  }
   return remix;
 }


### PR DESCRIPTION
As the [Remix release v0.25.1](https://github.com/ethereum/remix-project/releases/tag/v0.25.1) added the `deployProxy` query parameter to auto enable the UUPS contracts deploy proxy.  As described by @htadashi on https://github.com/OpenZeppelin/contracts-wizard/issues/155:
> the warning tooltip introduced in https://github.com/OpenZeppelin/contracts-wizard/issues/63 can be removed  if the UUPS option is selected.

Note: Remix added support for UUPS only and the warning can be removed in this case, although the transparent upgradeability will still need to show the warning.

Closes #155 