### PR TITLE
Error: spawn yarn ENOENT

### DIFF
--- a/packages/ui/rollup.config.mjs
+++ b/packages/ui/rollup.config.mjs
@@ -30,7 +30,7 @@ function onStartRun(cmd, ...args) {
   return {
     async buildStart() {
       if (ran) return;
-      const child = proc.spawn(cmd, args, { stdio: 'inherit' });
+      const child = proc.spawn(cmd, args, { stdio: 'inherit', shell: process.platform == 'win32' });
       const [code, signal] = await events.once(child, 'exit');
       if (code || signal) {
         throw new Error(`Command \`${cmd}\` failed`);


### PR DESCRIPTION
Adding option to proc.spawn to fix bug on windows, this should fix the behaviour on windows but it will not affect non windows environments, this fix #229 issue