### PR TITLE
Prevent hijacking of link injection

### DIFF
--- a/packages/ui/src/utils/inject-hyperlinks.ts
+++ b/packages/ui/src/utils/inject-hyperlinks.ts
@@ -2,7 +2,7 @@ import { version as contractsVersion } from "@openzeppelin/contracts/package.jso
 
 export function injectHyperlinks(code: string) {
   // We are modifying HTML, so use HTML escaped chars. The pattern excludes paths that include /../ in the URL.
-  const importRegex = /(@openzeppelin\/)(contracts-upgradeable\/|contracts\/)((?:(?!\.\.)[^/]+\/)*?[^/]*?)(&quot;)/g
+  const importRegex = /&quot;(@openzeppelin\/)(contracts-upgradeable\/|contracts\/)((?:(?!\.\.)[^/]+\/)*?[^/]*?)&quot;/g
 
-  return code.replace(importRegex, `<a class="import-link" href="https://github.com/OpenZeppelin/openzeppelin-$2blob/v${contractsVersion}/contracts/$3" target="_blank" rel="noopener noreferrer">$1$2$3</a>$4`);
+  return code.replace(importRegex, `&quot;<a class="import-link" href="https://github.com/OpenZeppelin/openzeppelin-$2blob/v${contractsVersion}/contracts/$3" target="_blank" rel="noopener noreferrer">$1$2$3</a>&quot;`);
 }

--- a/packages/ui/src/utils/inject-hyperlinks.ts
+++ b/packages/ui/src/utils/inject-hyperlinks.ts
@@ -1,6 +1,8 @@
 import { version as contractsVersion } from "@openzeppelin/contracts/package.json";
 
 export function injectHyperlinks(code: string) {
-  const importRegex = /(@openzeppelin\/)(contracts-upgradeable\/|contracts\/)(.*)(&quot;)/g // we are modifying HTML, so use HTML escaped chars
+  // We are modifying HTML, so use HTML escaped chars. The pattern excludes paths that include /../ in the URL.
+  const importRegex = /(@openzeppelin\/)(contracts-upgradeable\/|contracts\/)((?:(?!\.\.)[^/]+\/)*?[^/]*?)(&quot;)/g
+
   return code.replace(importRegex, `<a class="import-link" href="https://github.com/OpenZeppelin/openzeppelin-$2blob/v${contractsVersion}/contracts/$3" target="_blank" rel="noopener noreferrer">$1$2$3</a>$4`);
 }


### PR DESCRIPTION
The code to inject hyperlinks can be "hijacked" in the sense that a string like `@openzeppelin/contracts/../../../../xyz` will produce an unintended link to another location. In combination with the ability to put in an arbitrary value in the name field, using the above string as name currently results in some bad HTML output.

![image](https://user-images.githubusercontent.com/481465/236935807-ea07d6dd-b95e-4259-ae73-58c49c6896e1.png)


This PR attempts to make link injection more robust by 1) preventing paths that contain `/../`, and 2) using non-greedy matching in the regular expression.