### PR TITLE
Change default voting delay for Governor

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - **Breaking change**: Update to OpenZeppelin Contracts 4.9. ([#252](https://github.com/OpenZeppelin/contracts-wizard/pull/252))
+- Change default voting delay to 1 day in `governor`.
 
 ## 0.2.3 (2023-03-23)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - **Breaking change**: Update to OpenZeppelin Contracts 4.9. ([#252](https://github.com/OpenZeppelin/contracts-wizard/pull/252))
-- Change default voting delay to 1 day in `governor`.
+- Change default voting delay to 1 day in `governor`. ([#258](https://github.com/OpenZeppelin/contracts-wizard/pull/258))
 
 ## 0.2.3 (2023-03-23)
 

--- a/packages/core/src/governor.test.ts
+++ b/packages/core/src/governor.test.ts
@@ -24,7 +24,7 @@ function testGovernor(title: string, opts: Partial<GovernorOptions>) {
   test(title, t => {
     t.is(governor.print(opts), printContract(buildGovernor({
       name: 'MyGovernor',
-      delay: '1 block',
+      delay: '1 day',
       period: '1 week',
       ...opts,
     })));

--- a/packages/core/src/governor.ts
+++ b/packages/core/src/governor.ts
@@ -11,7 +11,7 @@ import { durationToBlocks } from "./utils/duration";
 
 export const defaults: Required<GovernorOptions> = {
   name: 'MyGovernor',
-  delay: '1 block',
+  delay: '1 day',
   period: '1 week',
 
   votes: 'erc20votes',


### PR DESCRIPTION
Change default voting delay from 1 block to 1 day.