### PR TITLE
Use actions v4 and Node 18 for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/packages/core/src/zip-hardhat.test.ts
+++ b/packages/core/src/zip-hardhat.test.ts
@@ -113,7 +113,7 @@ async function extractAndRunPackage(zip: JSZip, c: Contract, t: ExecutionContext
     }
   }
 
-  let command = `cd "${tempFolder}" && npm config set scripts-prepend-node-path auto && npm install && npm test`;
+  let command = `cd "${tempFolder}" && npm install && npm test`;
   if (c.constructorArgs === undefined) {
     // only test deploying the contract if there are no constructor args needed
     command += ' && npx hardhat run scripts/deploy.ts';


### PR DESCRIPTION
Test with Node 18 as it is the current minimum supported LTS version. 

Closes #299 