### PR TITLE
Enable prefilling initial options from URL search parameters

### DIFF
--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -54,25 +54,16 @@
     $: {
       if (opts) {
         if (!initialValuesSet) {
+          opts.name = initialOpts.name ?? opts.name;
           switch (opts.kind) {
             case 'ERC20':
-              opts.name = initialOpts.name ?? opts.name;
-              opts.symbol = initialOpts.symbol ?? opts.symbol;
               opts.premint = initialOpts.premint ?? opts.premint;
-              break;
             case 'ERC721':
-              opts.name = initialOpts.name ?? opts.name;
               opts.symbol = initialOpts.symbol ?? opts.symbol;
               break;
             case 'ERC1155':
-              opts.name = initialOpts.name ?? opts.name;
-              break;
             case 'Governor':
-              opts.name = initialOpts.name ?? opts.name;
-              break;
             case 'Custom':
-              opts.name = initialOpts.name ?? opts.name;
-              break;
           }
           initialValuesSet = true;
         }

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -38,10 +38,13 @@
       dispatch('tab-change', tab);
     };
 
+    export let initialName: string | undefined = undefined;
+    let name: string | undefined;
+
     let allOpts: { [k in Kind]?: Required<KindedOptions[k]> } = {};
     let errors: { [k in Kind]?: OptionsErrorMessages } = {};
 
-    let contract: Contract = new ContractBuilder('MyToken');
+    let contract: Contract = new ContractBuilder(initialName ?? 'MyToken');
 
     $: functionCall && applyFunctionCall()
 
@@ -49,6 +52,10 @@
 
     $: {
       if (opts) {
+        if (name === undefined && initialName !== undefined) {
+          name = initialName;
+          opts.name = name;
+        }
         try {
           contract = buildGeneric(opts);
           errors[tab] = undefined;

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -39,7 +39,7 @@
     };
 
     export let initialName: string | undefined = undefined;
-    let name: string | undefined;
+    let initialNameSet = false;
 
     let allOpts: { [k in Kind]?: Required<KindedOptions[k]> } = {};
     let errors: { [k in Kind]?: OptionsErrorMessages } = {};
@@ -52,9 +52,9 @@
 
     $: {
       if (opts) {
-        if (name === undefined && initialName !== undefined) {
-          name = initialName;
-          opts.name = name;
+        if (!initialNameSet && initialName !== undefined) {
+          initialNameSet = true;
+          opts.name = initialName;
         }
         try {
           contract = buildGeneric(opts);

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -27,6 +27,7 @@
 
     import { saveAs } from 'file-saver';
     import { injectHyperlinks } from './utils/inject-hyperlinks';
+    import { InitialOptions } from './initial-options';
 
     const dispatch = createEventDispatcher();
 
@@ -38,13 +39,13 @@
       dispatch('tab-change', tab);
     };
 
-    export let initialName: string | undefined = undefined;
-    let initialNameSet = false;
+    export let initialOpts: InitialOptions = {};
+    let initialValuesSet = false;
 
     let allOpts: { [k in Kind]?: Required<KindedOptions[k]> } = {};
     let errors: { [k in Kind]?: OptionsErrorMessages } = {};
 
-    let contract: Contract = new ContractBuilder(initialName ?? 'MyToken');
+    let contract: Contract = new ContractBuilder(initialOpts.name ?? 'MyToken');
 
     $: functionCall && applyFunctionCall()
 
@@ -52,9 +53,28 @@
 
     $: {
       if (opts) {
-        if (!initialNameSet && initialName !== undefined) {
-          initialNameSet = true;
-          opts.name = initialName;
+        if (!initialValuesSet) {
+          switch (opts.kind) {
+            case 'ERC20':
+              opts.name = initialOpts.name ?? opts.name;
+              opts.symbol = initialOpts.symbol ?? opts.symbol;
+              opts.premint = initialOpts.premint ?? opts.premint;
+              break;
+            case 'ERC721':
+              opts.name = initialOpts.name ?? opts.name;
+              opts.symbol = initialOpts.symbol ?? opts.symbol;
+              break;
+            case 'ERC1155':
+              opts.name = initialOpts.name ?? opts.name;
+              break;
+            case 'Governor':
+              opts.name = initialOpts.name ?? opts.name;
+              break;
+            case 'Custom':
+              opts.name = initialOpts.name ?? opts.name;
+              break;
+          }
+          initialValuesSet = true;
         }
         try {
           contract = buildGeneric(opts);

--- a/packages/ui/src/cairo/App.svelte
+++ b/packages/ui/src/cairo/App.svelte
@@ -31,21 +31,37 @@
       dispatch('tab-change', tab);
     };
 
-    export let initialName: string | undefined = undefined;
-    let initialNameSet = false;
+    export let initialOpts: { name?: string, symbol?: string, premint?: string } = {};
+    let initialValuesSet = false;
 
     let allOpts: { [k in Kind]?: Required<KindedOptions[k]> } = {};
     let errors: { [k in Kind]?: OptionsErrorMessages } = {};
 
-    let contract: Contract = new ContractBuilder(initialName ?? 'MyToken');
+    let contract: Contract = new ContractBuilder(initialOpts.name ?? 'MyToken');
 
     $: opts = allOpts[tab];
 
     $: {
       if (opts) {
-        if (!initialNameSet && initialName !== undefined) {
-          initialNameSet = true;
-          opts.name = initialName;
+        if (!initialValuesSet) {
+          switch (opts.kind) {
+            case 'ERC20':
+              opts.name = initialOpts.name ?? opts.name;
+              opts.symbol = initialOpts.symbol ?? opts.symbol;
+              opts.premint = initialOpts.premint ?? opts.premint;
+              break;
+            case 'ERC721':
+              opts.name = initialOpts.name ?? opts.name;
+              opts.symbol = initialOpts.symbol ?? opts.symbol;
+              break;
+            case 'ERC1155':
+              opts.name = initialOpts.name ?? opts.name;
+              break;
+            case 'Custom':
+              opts.name = initialOpts.name ?? opts.name;
+              break;
+          }
+          initialValuesSet = true;
         }
         try {
           contract = buildGeneric(opts);

--- a/packages/ui/src/cairo/App.svelte
+++ b/packages/ui/src/cairo/App.svelte
@@ -20,6 +20,7 @@
 
     import { saveAs } from 'file-saver';
     import { injectHyperlinks } from './inject-hyperlinks';
+    import { InitialOptions } from '../initial-options';
 
     const dispatch = createEventDispatcher();
 
@@ -31,7 +32,7 @@
       dispatch('tab-change', tab);
     };
 
-    export let initialOpts: { name?: string, symbol?: string, premint?: string } = {};
+    export let initialOpts: InitialOptions = {};
     let initialValuesSet = false;
 
     let allOpts: { [k in Kind]?: Required<KindedOptions[k]> } = {};

--- a/packages/ui/src/cairo/App.svelte
+++ b/packages/ui/src/cairo/App.svelte
@@ -31,15 +31,22 @@
       dispatch('tab-change', tab);
     };
 
+    export let initialName: string | undefined = undefined;
+    let name: string | undefined;
+
     let allOpts: { [k in Kind]?: Required<KindedOptions[k]> } = {};
     let errors: { [k in Kind]?: OptionsErrorMessages } = {};
 
-    let contract: Contract = new ContractBuilder('MyToken');
+    let contract: Contract = new ContractBuilder(initialName ?? 'MyToken');
 
     $: opts = allOpts[tab];
 
     $: {
       if (opts) {
+        if (name === undefined && initialName !== undefined) {
+          name = initialName;
+          opts.name = name;
+        }
         try {
           contract = buildGeneric(opts);
           errors[tab] = undefined;

--- a/packages/ui/src/cairo/App.svelte
+++ b/packages/ui/src/cairo/App.svelte
@@ -32,7 +32,7 @@
     };
 
     export let initialName: string | undefined = undefined;
-    let name: string | undefined;
+    let initialNameSet = false;
 
     let allOpts: { [k in Kind]?: Required<KindedOptions[k]> } = {};
     let errors: { [k in Kind]?: OptionsErrorMessages } = {};
@@ -43,9 +43,9 @@
 
     $: {
       if (opts) {
-        if (name === undefined && initialName !== undefined) {
-          name = initialName;
-          opts.name = name;
+        if (!initialNameSet && initialName !== undefined) {
+          initialNameSet = true;
+          opts.name = initialName;
         }
         try {
           contract = buildGeneric(opts);

--- a/packages/ui/src/cairo/App.svelte
+++ b/packages/ui/src/cairo/App.svelte
@@ -44,22 +44,15 @@
     $: {
       if (opts) {
         if (!initialValuesSet) {
+          opts.name = initialOpts.name ?? opts.name;
           switch (opts.kind) {
             case 'ERC20':
-              opts.name = initialOpts.name ?? opts.name;
-              opts.symbol = initialOpts.symbol ?? opts.symbol;
               opts.premint = initialOpts.premint ?? opts.premint;
-              break;
             case 'ERC721':
-              opts.name = initialOpts.name ?? opts.name;
               opts.symbol = initialOpts.symbol ?? opts.symbol;
               break;
             case 'ERC1155':
-              opts.name = initialOpts.name ?? opts.name;
-              break;
             case 'Custom':
-              opts.name = initialOpts.name ?? opts.name;
-              break;
           }
           initialValuesSet = true;
         }

--- a/packages/ui/src/embed.ts
+++ b/packages/ui/src/embed.ts
@@ -39,12 +39,19 @@ onDOMContentLoaded(function () {
     setSearchParam(w, src.searchParams, 'data-lang', 'lang');
     setSearchParam(w, src.searchParams, 'data-tab', 'tab');
     setSearchParam(w, src.searchParams, 'version', 'version');
+
     const sync = w.getAttribute('data-sync-url');
 
     if (sync === 'fragment') {
-      const fragment = window.location.hash.replace('#', '');
-      if (fragment) {
-        src.searchParams.set('tab', fragment);
+      // Uses format: #tab&key=value&key=value...
+      const fragments = window.location.hash.replace('#', '').split('&');
+      for (const fragment of fragments) {
+        const [key, value] = fragment.split('=', 2);
+        if (key && value) {
+          src.searchParams.set(key, value);
+        } else {
+          src.searchParams.set('tab', fragment);
+        }
       }
     }
 

--- a/packages/ui/src/initial-options.ts
+++ b/packages/ui/src/initial-options.ts
@@ -1,0 +1,1 @@
+export interface InitialOptions { name?: string, symbol?: string, premint?: string };

--- a/packages/ui/src/main.ts
+++ b/packages/ui/src/main.ts
@@ -8,6 +8,7 @@ import UnsupportedVersion from './UnsupportedVersion.svelte';
 import semver from 'semver';
 import { compatibleContractsSemver as compatibleSolidityContractsSemver } from '@openzeppelin/wizard';
 import { compatibleContractsSemver as compatibleCairoContractsSemver } from '@openzeppelin/wizard-cairo';
+import { InitialOptions } from './initial-options';
 
 function postResize() {
   const { height } = document.documentElement.getBoundingClientRect();
@@ -24,7 +25,12 @@ const params = new URLSearchParams(window.location.search);
 const initialTab = params.get('tab') ?? undefined;
 const lang = params.get('lang') ?? undefined;
 const requestedVersion = params.get('version') ?? undefined;
-const initialName = params.get('name') ?? undefined;
+
+const initialOpts: InitialOptions = {
+  name: params.get('name') ?? undefined,
+  symbol: params.get('symbol') ?? undefined,
+  premint: params.get('premint') ?? undefined,
+}
 
 let compatibleVersionSemver = lang === 'cairo' ? compatibleCairoContractsSemver : compatibleSolidityContractsSemver;
 
@@ -33,9 +39,9 @@ if (requestedVersion && !semver.satisfies(requestedVersion, compatibleVersionSem
   postMessage({ kind: 'oz-wizard-unsupported-version' });
   app = new UnsupportedVersion({ target: document.body, props: { requestedVersion, compatibleVersionSemver }});
 } else if (lang === 'cairo') {
-  app = new CairoApp({ target: document.body, props: { initialTab, initialName } });
+  app = new CairoApp({ target: document.body, props: { initialTab, initialOpts } });
 } else {
-  app = new App({ target: document.body, props: { initialTab, initialName } });
+  app = new App({ target: document.body, props: { initialTab, initialOpts } });
 }
 
 app.$on('tab-change', (e: CustomEvent) => {

--- a/packages/ui/src/main.ts
+++ b/packages/ui/src/main.ts
@@ -24,6 +24,7 @@ const params = new URLSearchParams(window.location.search);
 const initialTab = params.get('tab') ?? undefined;
 const lang = params.get('lang') ?? undefined;
 const requestedVersion = params.get('version') ?? undefined;
+const initialName = params.get('name') ?? undefined;
 
 let compatibleVersionSemver = lang === 'cairo' ? compatibleCairoContractsSemver : compatibleSolidityContractsSemver;
 
@@ -32,9 +33,9 @@ if (requestedVersion && !semver.satisfies(requestedVersion, compatibleVersionSem
   postMessage({ kind: 'oz-wizard-unsupported-version' });
   app = new UnsupportedVersion({ target: document.body, props: { requestedVersion, compatibleVersionSemver }});
 } else if (lang === 'cairo') {
-  app = new CairoApp({ target: document.body, props: { initialTab } });
+  app = new CairoApp({ target: document.body, props: { initialTab, initialName } });
 } else {
-  app = new App({ target: document.body, props: { initialTab } });
+  app = new App({ target: document.body, props: { initialTab, initialName } });
 }
 
 app.$on('tab-change', (e: CustomEvent) => {


### PR DESCRIPTION
Enables the `name`, `symbol`, and `premint` options to be prefilled from URL search parameters.

Previously the string content after `#` in the URL was treated as the tab (e.g. `erc20` or `erc721`)

With this PR, it splits that string content into further fragments, where a fragment can be just the tab as before, or fragments can be additional `key=value` pairs.

For example: https://wizard.openzeppelin.com/cairo#erc721&name=MyContractName would go to the Cairo language with `tab=erc721` and `name=MyContractName`