### PR TITLE
Fix build for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         if: matrix.package == 'core'
         uses: foundry-rs/foundry-toolchain@v1
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --network-concurrency 1
       - name: Compile TypeScript
         run: yarn tsc
         working-directory: packages/${{matrix.package}}


### PR DESCRIPTION
#404 added the git repository https://github.com/OpenZeppelin/openzeppelin-community-contracts/ as a dependency.  This caused the test builds to encounter issue https://github.com/yarnpkg/yarn/issues/7212.

As a workaround, as described in a comment in that yarn issue, we can use `yarn install --network-concurrency 1`.

This can be reverted when we release https://github.com/OpenZeppelin/openzeppelin-community-contracts/ as an NPM package and switch the dependency to use that.