### PR TITLE
Prevent line breaks in labels

### DIFF
--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -178,7 +178,7 @@
   <Wiz bind:functionCall={functionCall} bind:currentOpts={opts}></Wiz>
 
   <div class="header flex flex-row justify-between">
-    <div class="tab overflow-hidden">
+    <div class="tab overflow-hidden whitespace-nowrap">
       <OverflowMenu>
         <button class:selected={tab === 'ERC20'} on:click={() => tab = 'ERC20'}>
           ERC20


### PR DESCRIPTION
Prevent line wrapping from whitespace in contract type labels.  This ensures the button labels are all single line.

Related to #404