### PR TITLE
Fixing edge case when import files with same contract name at least two times

### DIFF
--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -5,6 +5,7 @@ export interface Contract {
   license: string;
   parents: Parent[];
   natspecTags: NatspecTag[];
+  modules: ImportContract[];
   imports: ImportContract[];
   functions: ContractFunction[];
   constructorCode: string[];
@@ -80,6 +81,7 @@ export class ContractBuilder implements Contract {
   upgradeable = false;
 
   readonly using: Using[] = [];
+  readonly modules: ImportContract[] = [];
   readonly natspecTags: NatspecTag[] = [];
 
   readonly constructorArgs: FunctionArgument[] = [];
@@ -109,6 +111,7 @@ export class ContractBuilder implements Contract {
     return [
       ...[...this.parentMap.values()].map(p => p.contract),
       ...this.using.map(u => u.library),
+      ...this.modules,
     ];
   }
 
@@ -126,10 +129,8 @@ export class ContractBuilder implements Contract {
     return !present;
   }
 
-  addImportOnly(contract: ImportContract): boolean {
-    const present = this.parentMap.has(contract.name);
-    this.parentMap.set(contract.name, { contract, params: [], importOnly: true });
-    return !present;
+  addImportOnly(contract: ImportContract) {
+    this.modules.push(contract);
   }
 
   addOverride(parent: ReferencedContract, baseFn: BaseFunction, mutability?: FunctionMutability) {

--- a/packages/core/src/print.ts
+++ b/packages/core/src/print.ts
@@ -258,7 +258,11 @@ function printImports(imports: ImportContract[], helpers: Helpers): string[] {
   const lines: string[] = [];
   imports.map(p => {
     const importContract = helpers.transformImport(p);
-    lines.push(`import {${importContract.name}} from "${importContract.path}";`);
+    if (importContract.name === ''){
+      lines.push(`import "${importContract.path}";`);
+    } else{
+      lines.push(`import {${importContract.name}} from "${importContract.path}";`);
+    }
   });
 
   return lines;


### PR DESCRIPTION
There is an edge case as following:

Suppose I would like to accomplish following code block:

```
pragma solidity ^0.8.20;

import "@redprint-core/cannon/libraries/CannonErrors.sol";
import "@redprint-core/cannon/libraries/CannonTypes.sol";
```


and I use :


```
    const CannonErrors = {
        name: '',
        path: '@redprint-core/cannon/libraries/CannonErrors.sol',
    };
    c.addImportOnly(CannonErrors);
    const CannonTypes = {
        name: '',
        path: '@redprint-core/cannon/libraries/CannonTypes.sol',
    };    
    c.addImportOnly(CannonTypes);

```

However, it will generate only one path with excessive  `{} from` as following  : 


```
/ SPDX-License-Identifier: MIT
pragma solidity ^0.8.20;

import {} from "@redprint-core/cannon/libraries/CannonErrors.sol";

```

Adding additional state of  ` readonly modules: ImportContract[] = [];` with modified `contract.ts` and `print.ts` 's functions as PR will solve this:

Please suggest if this is not appropriate, I am happy to make another PR.

Reference to  : [my repo](https://github.com/Ratimon/redprint-wizard/commit/4207f911fcfacd0a157a892e226fbc15ae0458b5)

Regards

