### PR TITLE
Remove `isAccessControlRequired` from specific contract APIs, update copyright year

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 OpenZeppelin Contracts Wizard
-Copyright (C) 2021-2024  Zeppelin Group Ltd
+Copyright (C) 2021-2025  Zeppelin Group Ltd
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3.
 

--- a/packages/core-cairo/CHANGELOG.md
+++ b/packages/core-cairo/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 0.21.0 (2025-01-09)
+## 0.21.0 (2025-01-13)
 
 - Add Vesting tab. ([#425](https://github.com/OpenZeppelin/contracts-wizard/pull/425))
+- Remove `isAccessControlRequired` from `governor` and `vesting`.
 - Update Contracts Wizard license to AGPLv3. ([#424](https://github.com/OpenZeppelin/contracts-wizard/pull/424))
 
 ## 0.20.1 (2024-12-17)

--- a/packages/core-cairo/CHANGELOG.md
+++ b/packages/core-cairo/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add Vesting tab. ([#425](https://github.com/OpenZeppelin/contracts-wizard/pull/425))
 
 - **Breaking changes**:
-  - Remove `isAccessControlRequired` from `governor` and `vesting`.
+  - Remove `isAccessControlRequired` from `governor` and `vesting`. ([#426](https://github.com/OpenZeppelin/contracts-wizard/pull/426))
   - Update Contracts Wizard license to AGPLv3. ([#424](https://github.com/OpenZeppelin/contracts-wizard/pull/424))
 
 ## 0.20.1 (2024-12-17)

--- a/packages/core-cairo/CHANGELOG.md
+++ b/packages/core-cairo/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## 0.21.0 (2025-01-13)
 
 - Add Vesting tab. ([#425](https://github.com/OpenZeppelin/contracts-wizard/pull/425))
-- Remove `isAccessControlRequired` from `governor` and `vesting`.
-- Update Contracts Wizard license to AGPLv3. ([#424](https://github.com/OpenZeppelin/contracts-wizard/pull/424))
+
+- **Breaking changes**:
+  - Remove `isAccessControlRequired` from `governor` and `vesting`.
+  - Update Contracts Wizard license to AGPLv3. ([#424](https://github.com/OpenZeppelin/contracts-wizard/pull/424))
 
 ## 0.20.1 (2024-12-17)
 

--- a/packages/core-cairo/NOTICE
+++ b/packages/core-cairo/NOTICE
@@ -1,5 +1,5 @@
 OpenZeppelin Contracts Wizard
-Copyright (C) 2021-2024  Zeppelin Group Ltd
+Copyright (C) 2021-2025  Zeppelin Group Ltd
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3.
 

--- a/packages/core-cairo/README.md
+++ b/packages/core-cairo/README.md
@@ -17,6 +17,8 @@ The following contract types are supported:
 - `erc721`
 - `erc1155`
 - `account`
+- `governor`
+- `vesting`
 - `custom`
 
 Each contract type has functions/constants as defined below.
@@ -37,6 +39,12 @@ function print(opts?: ERC1155Options): string
 function print(opts?: AccountOptions): string
 ```
 ```js
+function print(opts?: GovernorOptions): string
+```
+```js
+function print(opts?: VestingOptions): string
+```
+```js
 function print(opts?: CustomOptions): string
 ```
 Returns a string representation of a contract generated using the provided options. If `opts` is not provided, uses [`defaults`](#defaults).
@@ -53,6 +61,12 @@ const defaults: Required<ERC1155Options>
 ```
 ```js
 const defaults: Required<AccountOptions>
+```
+```js
+const defaults: Required<GovernorOptions>
+```
+```js
+const defaults: Required<VestingOptions>
 ```
 ```js
 const defaults: Required<CustomOptions>
@@ -74,8 +88,8 @@ function isAccessControlRequired(opts: Partial<CustomOptions>): boolean
 ```
 Whether any of the provided options require access control to be enabled. If this returns `true`, then calling `print` with the same options would cause the `access` option to default to `'ownable'` if it was `undefined` or `false`. 
 
-> Note that account contracts handle permissions differently from the other supported contracts.
-Thus, the `account` contract type does not include `isAccessControlRequired`.
+> Note that contracts such as `account`, `governor`, and `vesting` have their own ways of handling permissions and do not support the `access` option.
+Thus, those types do not include `isAccessControlRequired`.
 
 ### Contract specific functions
 

--- a/packages/core-cairo/src/api.ts
+++ b/packages/core-cairo/src/api.ts
@@ -3,9 +3,9 @@ import { printERC20, defaults as erc20defaults, isAccessControlRequired as erc20
 import { printERC721, defaults as erc721defaults, isAccessControlRequired as erc721IsAccessControlRequired, ERC721Options } from './erc721';
 import { printERC1155, defaults as erc1155defaults, isAccessControlRequired as erc1155IsAccessControlRequired, ERC1155Options } from './erc1155';
 import { printAccount, defaults as accountDefaults, AccountOptions } from './account';
-import { printGovernor, defaults as governorDefaults, isAccessControlRequired as governorIsAccessControlRequired, GovernorOptions } from './governor';
+import { printGovernor, defaults as governorDefaults, GovernorOptions } from './governor';
 import { printCustom, defaults as customDefaults, isAccessControlRequired as customIsAccessControlRequired, CustomOptions } from './custom';
-import { printVesting, defaults as vestingDefaults, isAccessControlRequired as vestingIsAccessControlRequired, VestingOptions } from './vesting';
+import { printVesting, defaults as vestingDefaults, VestingOptions } from './vesting';
 
 export interface WizardAccountAPI<Options extends CommonOptions>{
   /**
@@ -29,21 +29,23 @@ export interface WizardContractAPI<Options extends CommonContractOptions> {
    * The default options that are used for `print`.
    */
   defaults: Required<Options>;
+}
 
+export interface AccessControlAPI<Options extends CommonContractOptions> {
   /**
    * Whether any of the provided options require access control to be enabled. If this returns `true`, then calling `print` with the 
    * same options would cause the `access` option to default to `'ownable'` if it was `undefined` or `false`.
    */
-   isAccessControlRequired: (opts: Partial<Options>) => boolean;
+  isAccessControlRequired: (opts: Partial<Options>) => boolean;
 }
 
-export type ERC20 = WizardContractAPI<ERC20Options>;
-export type ERC721 = WizardContractAPI<ERC721Options>;
-export type ERC1155 = WizardContractAPI<ERC1155Options>;
+export type ERC20 = WizardContractAPI<ERC20Options> & AccessControlAPI<ERC20Options>;
+export type ERC721 = WizardContractAPI<ERC721Options> & AccessControlAPI<ERC721Options>;
+export type ERC1155 = WizardContractAPI<ERC1155Options> & AccessControlAPI<ERC1155Options>;
 export type Account = WizardAccountAPI<AccountOptions>;
 export type Governor = WizardContractAPI<GovernorOptions>;
 export type Vesting = WizardContractAPI<VestingOptions>;
-export type Custom = WizardContractAPI<CustomOptions>;
+export type Custom = WizardContractAPI<CustomOptions> & AccessControlAPI<CustomOptions>;
 
 export const erc20: ERC20 = {
   print: printERC20,
@@ -67,12 +69,10 @@ export const account: Account = {
 export const governor: Governor = {
   print: printGovernor,
   defaults: governorDefaults,
-  isAccessControlRequired: governorIsAccessControlRequired
 }
 export const vesting: Vesting = {
   print: printVesting,
   defaults: vestingDefaults,
-  isAccessControlRequired: vestingIsAccessControlRequired
 }
 export const custom: Custom = {
   print: printCustom,

--- a/packages/core-cairo/src/governor.ts
+++ b/packages/core-cairo/src/governor.ts
@@ -65,10 +65,6 @@ export interface GovernorOptions extends CommonOptions {
   appVersion?: string;
 }
 
-export function isAccessControlRequired(opts: Partial<GovernorOptions>): boolean {
-  return false;
-}
-
 function withDefaults(opts: GovernorOptions): Required<GovernorOptions> {
   return {
     ...opts,

--- a/packages/core-cairo/src/vesting.test.ts
+++ b/packages/core-cairo/src/vesting.test.ts
@@ -109,10 +109,6 @@ testAPIEquivalence('API all custom settings', {
   schedule: 'custom'
 });
 
-test('Vesting API isAccessControlRequired', async t => {
-  t.is(vesting.isAccessControlRequired({}), true);
-});
-
 test('cliff too high', async t => {
   const error = t.throws(() => buildVesting({
     ...defaults,

--- a/packages/core-cairo/src/vesting.ts
+++ b/packages/core-cairo/src/vesting.ts
@@ -44,10 +44,6 @@ function withDefaults(opts: VestingOptions): Required<VestingOptions> {
   };
 }
 
-export function isAccessControlRequired(_: Partial<VestingOptions>): boolean {
-  return true;
-}
-
 export function buildVesting(opts: VestingOptions): Contract {
   const c = new ContractBuilder(opts.name);
   const allOpts = withDefaults(opts);

--- a/packages/core/NOTICE
+++ b/packages/core/NOTICE
@@ -1,5 +1,5 @@
 OpenZeppelin Contracts Wizard
-Copyright (C) 2021-2024  Zeppelin Group Ltd
+Copyright (C) 2021-2025  Zeppelin Group Ltd
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3.
 

--- a/packages/ui/public/cairo.html
+++ b/packages/ui/public/cairo.html
@@ -58,7 +58,7 @@
   </div>
 
   <footer>
-    <p>© <a href="https://openzeppelin.com" target="_blank" rel="noopener noreferrer">OpenZeppelin</a> 2022-2024 |&nbsp;<a href="https://openzeppelin.com/privacy" target="_blank" rel="noopener noreferrer">Privacy</a> |&nbsp;<a href="https://openzeppelin.com/tos" target="_blank" rel="noopener noreferrer">Terms of Service</a></p>
+    <p>© <a href="https://openzeppelin.com" target="_blank" rel="noopener noreferrer">OpenZeppelin</a> 2022-2025 |&nbsp;<a href="https://openzeppelin.com/privacy" target="_blank" rel="noopener noreferrer">Privacy</a> |&nbsp;<a href="https://openzeppelin.com/tos" target="_blank" rel="noopener noreferrer">Terms of Service</a></p>
   </footer>
 
 <!-- Start of HubSpot Embed Code -->

--- a/packages/ui/public/index.html
+++ b/packages/ui/public/index.html
@@ -90,7 +90,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 
   <footer>
-    <p>© <a href="https://openzeppelin.com" target="_blank" rel="noopener noreferrer">OpenZeppelin</a> 2017-2024 |&nbsp;<a href="https://openzeppelin.com/privacy" target="_blank" rel="noopener noreferrer">Privacy</a> |&nbsp;<a href="https://openzeppelin.com/tos" target="_blank" rel="noopener noreferrer">Terms of Service</a></p>
+    <p>© <a href="https://openzeppelin.com" target="_blank" rel="noopener noreferrer">OpenZeppelin</a> 2017-2025 |&nbsp;<a href="https://openzeppelin.com/privacy" target="_blank" rel="noopener noreferrer">Privacy</a> |&nbsp;<a href="https://openzeppelin.com/tos" target="_blank" rel="noopener noreferrer">Terms of Service</a></p>
   </footer>
 
 <!-- Start of HubSpot Embed Code -->


### PR DESCRIPTION
- Removes the `isAccessControlRequired` function from the APIs for `governor` and `vesting` by separating their interfaces from contracts that have access control options.
  - Although `account`, `governor`, and `vesting` have their own ways of handling access control, they don't require this function because it's only purpose was to allow the caller to inspect the default behavior of the `access` option.
- Update Cairo API readme.
- Updates copyright year in preparation for publishing.