### PR TITLE
Append `allow="clipboard-write"` to wizard embed iframe

### DIFF
--- a/packages/ui/src/embed.ts
+++ b/packages/ui/src/embed.ts
@@ -61,6 +61,7 @@ onDOMContentLoaded(function () {
     iframe.style.border = '0';
     iframe.style.width = '100%';
     iframe.style.height = 'calc(100vh - 100px)';
+    iframe.allow = 'clipboard-write';
 
     w.appendChild(iframe);
 


### PR DESCRIPTION
Resolves https://github.com/OpenZeppelin/contracts-wizard/issues/295

As per [Mozilla's Clipboard API docs](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#security_considerations):

> Chromium browsers:
> ...
>    - The HTTP [Permissions-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy) permissions clipboard-read and clipboard-write must be allowed for [<iframe>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) elements that access the clipboard.

I verified this is the probable root of the issue by doing the following:
- open _packages/ui/public/index.html_
- comment out `div class="wizard-container"` which includes the nested `oz-wizard` component
- below it, paste the exact `iframe` code that's injected into [the docs website](https://docs.openzeppelin.com/contracts/5.x/wizard):
```html
<iframe src="https://wizard.openzeppelin.com/embed" style="display: block; border: 0px; width: 100%; height: calc(-100px + 100vh); --darkreader-inline-border-top: currentcolor; --darkreader-inline-border-right: currentcolor; --darkreader-inline-border-bottom: currentcolor; --darkreader-inline-border-left: currentcolor;" data-darkreader-inline-border-top="" data-darkreader-inline-border-right="" data-darkreader-inline-border-bottom="" data-darkreader-inline-border-left=""></iframe>
```
- run `yarn dev` for the UI
- open the localhost:8080 in Chrome
- click on "Copy to Clipboard" button
- **nothing happens -> the issue is reproduced**

I then added the `allow="clipboard-write"` attribute to the `iframe`, making it:
```html
<iframe src="https://wizard.openzeppelin.com/embed" allow="clipboard-write" style="display: block; border: 0px; width: 100%; height: calc(-100px + 100vh); --darkreader-inline-border-top: currentcolor; --darkreader-inline-border-right: currentcolor; --darkreader-inline-border-bottom: currentcolor; --darkreader-inline-border-left: currentcolor;" data-darkreader-inline-border-top="" data-darkreader-inline-border-right="" data-darkreader-inline-border-bottom="" data-darkreader-inline-border-left=""></iframe>
```
- reload the page on Chrome
- click on "Copy to Clipboard" button
- **code was copied** :heavy_check_mark: 