### PR TITLE
Add premint chainId to Stablecoin and RWA tabs

### DIFF
--- a/packages/ui/src/solidity/App.svelte
+++ b/packages/ui/src/solidity/App.svelte
@@ -402,10 +402,10 @@
         <ERC1155Controls bind:opts={allOpts.ERC1155} />
       </div>
       <div class:hidden={tab !== 'Stablecoin'}>
-        <StablecoinControls bind:opts={allOpts.Stablecoin} />
+        <StablecoinControls bind:opts={allOpts.Stablecoin} errors={errors.Stablecoin} />
       </div>
       <div class:hidden={tab !== 'RealWorldAsset'}>
-        <RealWorldAssetControls bind:opts={allOpts.RealWorldAsset} />
+        <RealWorldAssetControls bind:opts={allOpts.RealWorldAsset} errors={errors.RealWorldAsset} />
       </div>
       <div class:hidden={tab !== 'Governor'}>
         <GovernorControls bind:opts={allOpts.Governor} errors={errors.Governor} />

--- a/packages/ui/src/solidity/ERC20Controls.svelte
+++ b/packages/ui/src/solidity/ERC20Controls.svelte
@@ -75,7 +75,7 @@
     <p class="subcontrol tooltip-container flex justify-between items-center pr-2">
       <label class="text-sm flex-1">
         &nbsp;Chain ID:
-        <input type="number" bind:value={opts.premintChainId} placeholder={''} class="input-inline" use:resizeToFit use:error={errors?.premintChainId}>
+        <input type="number" bind:value={opts.premintChainId} placeholder={''} pattern={chainIdPattern.source} class="input-inline" use:resizeToFit use:error={errors?.premintChainId}>
       </label>
       <HelpTooltip>Chain ID of the network on which to premint tokens.</HelpTooltip>
     </p>

--- a/packages/ui/src/solidity/RealWorldAssetControls.svelte
+++ b/packages/ui/src/solidity/RealWorldAssetControls.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
   import HelpTooltip from '../common/HelpTooltip.svelte';
 
-  import type { KindedOptions } from '@openzeppelin/wizard';
-  import { realWorldAsset, premintPattern, infoDefaults } from '@openzeppelin/wizard';
+  import type { KindedOptions, OptionsErrorMessages } from '@openzeppelin/wizard';
+  import { realWorldAsset, premintPattern, chainIdPattern, infoDefaults } from '@openzeppelin/wizard';
 
   import AccessControlSection from './AccessControlSection.svelte';
   import InfoSection from './InfoSection.svelte';
   import ToggleRadio from '../common/inputs/ToggleRadio.svelte';
   import OPIcon from '../common/icons/OPIcon.svelte';
+  import { error } from '../common/error-tooltip';
+  import { resizeToFit } from '../common/resize-to-fit';
   import { superchainTooltipProps } from './superchain-tooltip';
 
   export let opts: Required<KindedOptions['RealWorldAsset']> = {
@@ -18,6 +20,8 @@
     premint: '', // default to empty premint in UI instead of 0
     info: { ...infoDefaults }, // create new object since Info is nested
   };
+
+  export let errors: undefined | OptionsErrorMessages;
 
   $: requireAccessControl = realWorldAsset.isAccessControlRequired(opts);
 
@@ -37,6 +41,11 @@
       superchainTooltip.show();
     }
     wasSuperchain = opts.crossChainBridging === 'superchain';
+  }
+
+  let showChainId = false;
+  $: {
+    showChainId = opts.premint !== '' && opts.premint !== '0' && opts.crossChainBridging !== false;
   }
 </script>
 
@@ -66,8 +75,18 @@
         Premint
         <HelpTooltip>Create an initial amount of tokens for the deployer.</HelpTooltip>
       </span>
-      <input bind:value={opts.premint} placeholder="0" pattern={premintPattern.source}>
+      <input bind:value={opts.premint} placeholder="0" pattern={premintPattern.source} use:error={errors?.premint}>
     </label>
+
+    {#if showChainId}
+    <p class="subcontrol tooltip-container flex justify-between items-center pr-2">
+      <label class="text-sm flex-1">
+        &nbsp;Chain ID:
+        <input type="number" bind:value={opts.premintChainId} placeholder={''} pattern={chainIdPattern.source} class="input-inline" use:resizeToFit use:error={errors?.premintChainId}>
+      </label>
+      <HelpTooltip>Chain ID of the network on which to premint tokens.</HelpTooltip>
+    </p>
+    {/if}
 </section>
 
 <section class="controls-section">

--- a/packages/ui/src/solidity/StablecoinControls.svelte
+++ b/packages/ui/src/solidity/StablecoinControls.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
   import HelpTooltip from '../common/HelpTooltip.svelte';
 
-  import type { KindedOptions } from '@openzeppelin/wizard';
-  import { stablecoin, premintPattern, infoDefaults } from '@openzeppelin/wizard';
+  import type { KindedOptions, OptionsErrorMessages } from '@openzeppelin/wizard';
+  import { stablecoin, premintPattern, chainIdPattern, infoDefaults } from '@openzeppelin/wizard';
 
   import AccessControlSection from './AccessControlSection.svelte';
   import InfoSection from './InfoSection.svelte';
   import ToggleRadio from '../common/inputs/ToggleRadio.svelte';
   import OPIcon from '../common/icons/OPIcon.svelte';
+  import { error } from '../common/error-tooltip';
+  import { resizeToFit } from '../common/resize-to-fit';
   import { superchainTooltipProps } from './superchain-tooltip';
 
   export let opts: Required<KindedOptions['Stablecoin']> = {
@@ -16,6 +18,8 @@
     premint: '', // default to empty premint in UI instead of 0
     info: { ...infoDefaults }, // create new object since Info is nested
   };
+
+  export let errors: undefined | OptionsErrorMessages;
 
   $: requireAccessControl = stablecoin.isAccessControlRequired(opts);
 
@@ -35,6 +39,11 @@
       superchainTooltip.show();
     }
     wasSuperchain = opts.crossChainBridging === 'superchain';
+  }
+
+  let showChainId = false;
+  $: {
+    showChainId = opts.premint !== '' && opts.premint !== '0' && opts.crossChainBridging !== false;
   }
 </script>
 
@@ -64,8 +73,18 @@
         Premint
         <HelpTooltip>Create an initial amount of tokens for the deployer.</HelpTooltip>
       </span>
-      <input bind:value={opts.premint} placeholder="0" pattern={premintPattern.source}>
+      <input bind:value={opts.premint} placeholder="0" pattern={premintPattern.source} use:error={errors?.premint}>
     </label>
+
+    {#if showChainId}
+    <p class="subcontrol tooltip-container flex justify-between items-center pr-2">
+      <label class="text-sm flex-1">
+        &nbsp;Chain ID:
+        <input type="number" bind:value={opts.premintChainId} placeholder={''} pattern={chainIdPattern.source} class="input-inline" use:resizeToFit use:error={errors?.premintChainId}>
+      </label>
+      <HelpTooltip>Chain ID of the network on which to premint tokens.</HelpTooltip>
+    </p>
+    {/if}
 </section>
 
 <section class="controls-section">


### PR DESCRIPTION
Chain ID is required when using Premint with Cross-Chain Bridging.  The Chain ID field is in the ERC20 tab but missing from Stablecoin and RWA tabs.