### PR TITLE
fix: Safari rendering issues with code preview when switching tabs or scrolling

### DIFF
--- a/packages/ui/src/solidity/App.svelte
+++ b/packages/ui/src/solidity/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { createEventDispatcher } from 'svelte';
+    import { createEventDispatcher, tick } from 'svelte';
 
     import hljs from './highlightjs';
 
@@ -37,15 +37,18 @@
 
     const dispatch = createEventDispatcher();
 
+    async function allowRendering() {
+      showCode = false;
+      await tick();
+      showCode = true;
+    }
+
     export let initialTab: string | undefined = 'ERC20';
 
     export let tab: Kind = sanitizeKind(initialTab);
     $: {
       tab = sanitizeKind(tab);
-      showCode = false;
-      setTimeout(() => {
-        showCode = true;
-      }, 0);
+      allowRendering();
       dispatch('tab-change', tab);
     };
 
@@ -93,10 +96,7 @@
             throw e;
           }
         }
-        showCode = false;
-        setTimeout(() => {
-          showCode = true;
-        }, 0);
+        allowRendering();
       }
     }
 

--- a/packages/ui/src/solidity/App.svelte
+++ b/packages/ui/src/solidity/App.svelte
@@ -42,6 +42,10 @@
     export let tab: Kind = sanitizeKind(initialTab);
     $: {
       tab = sanitizeKind(tab);
+      showCode = false;
+      setTimeout(() => {
+        showCode = true;
+      }, 0);
       dispatch('tab-change', tab);
     };
 
@@ -54,6 +58,8 @@
     let errors: { [k in Kind]?: OptionsErrorMessages } = {};
 
     let contract: Contract = new ContractBuilder(initialOpts.name ?? 'MyToken');
+
+    let showCode = true;
 
     $: functionCall && applyFunctionCall()
 
@@ -87,6 +93,10 @@
             throw e;
           }
         }
+        showCode = false;
+        setTimeout(() => {
+          showCode = true;
+        }, 0);
       }
     }
 
@@ -441,7 +451,9 @@
       </div>
       {/if}
       <pre class="flex flex-col grow basis-0 overflow-auto">
+        {#if showCode}
         <code class="hljs -solidity grow overflow-auto p-4 {hasErrors ? 'no-select' : ''}">{@html highlightedCode}</code>
+        {/if}
       </pre>
       <DefenderDeployModal isOpen={showDeployModal} />
     </div>


### PR DESCRIPTION
This PR fixes #466  in Safari browsers where the code preview would display incorrect or partially cached content when:
1. Switching between tabs (e.g., from ERC20 to Stablecoin)
2. Scrolling horizontally to view the full code
3. Changing contract settings

The issue was caused by Safari's rendering engine not properly repainting/reflowing the code preview container when content changes occurred in combination with horizontal scrolling. This resulted in showing stale or mixed content from previous states.

Fix:
- Added a force re-render mechanism that temporarily removes and re-adds the code preview element
- Applied the fix to both tab changes and contract option updates
- Set minimal timeout (0ms) to ensure the DOM has a chance to properly clear before re-rendering

The actual contract code and functionality remain unchanged - this only affects how Safari renders the content.

Testing:
1. Open the wizard in Safari (mobile or desktop)
2. Switch between tabs (especially ERC20 and Stablecoin)
3. Scroll horizontally to view full code
4. Verify that code preview always shows correct and complete content
5. Verify that contract features (copy, download, etc.) work as expected