### PR TITLE
Fix spacing in UI code display

### DIFF
--- a/packages/ui/src/cairo/App.svelte
+++ b/packages/ui/src/cairo/App.svelte
@@ -194,9 +194,7 @@
     <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)]">
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
-          <code class="hljs -cairo grow overflow-auto p-4">
-            {@html highlightedCode}
-          </code>
+          <code class="hljs -cairo grow overflow-auto p-4">{@html highlightedCode}</code>
         {/if}
       </pre>
     </div>

--- a/packages/ui/src/cairo_alpha/App.svelte
+++ b/packages/ui/src/cairo_alpha/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { createEventDispatcher } from 'svelte';
+    import { createEventDispatcher, tick } from 'svelte';
 
     import hljs from './highlightjs';
 
@@ -27,12 +27,20 @@
 
     const dispatch = createEventDispatcher();
 
+    let showCode = true;
+    async function allowRendering() {
+      showCode = false;
+      await tick();
+      showCode = true;
+    }
+
     export let initialTab: string | undefined = 'ERC20';
 
     export let tab: Kind = sanitizeKind(initialTab);
     $: {
       tab = sanitizeKind(tab);
       dispatch('tab-change', tab);
+      allowRendering();
     };
 
     export let initialOpts: InitialOptions = {};
@@ -74,6 +82,7 @@
           }
         }
       }
+      allowRendering();
     }
 
     $: code = printContract(contract);
@@ -183,7 +192,11 @@
       </div>
     </div>
     <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)]">
-      <pre class="flex flex-col grow basis-0 overflow-auto"><code class="hljs -cairo grow overflow-auto p-4">{@html highlightedCode}</code></pre>
+      <pre class="flex flex-col grow basis-0 overflow-auto">
+        {#if showCode}
+          <code class="hljs -cairo grow overflow-auto p-4">{@html highlightedCode}</code>
+        {/if}
+      </pre>
     </div>
   </div>
 </div>

--- a/packages/ui/src/solidity/App.svelte
+++ b/packages/ui/src/solidity/App.svelte
@@ -452,7 +452,7 @@
       {/if}
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
-        <code class="hljs -solidity grow overflow-auto p-4 {hasErrors ? 'no-select' : ''}">{@html highlightedCode}</code>
+          <code class="hljs -solidity grow overflow-auto p-4 {hasErrors ? 'no-select' : ''}">{@html highlightedCode}</code>
         {/if}
       </pre>
       <DefenderDeployModal isOpen={showDeployModal} />

--- a/packages/ui/src/stellar/App.svelte
+++ b/packages/ui/src/stellar/App.svelte
@@ -144,9 +144,7 @@
     <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)]">
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
-          <code class="hljs -stellar grow overflow-auto p-4">
-            {@html highlightedCode}
-          </code>
+          <code class="hljs -stellar grow overflow-auto p-4">{@html highlightedCode}</code>
         {/if}
     </div>
   </div>

--- a/packages/ui/src/stylus/App.svelte
+++ b/packages/ui/src/stylus/App.svelte
@@ -164,9 +164,7 @@
     <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)]">
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
-          <code class="hljs -stylus grow overflow-auto p-4">
-            {@html highlightedCode}
-          </code>
+          <code class="hljs -stylus grow overflow-auto p-4">{@html highlightedCode}</code>
         {/if}
       </pre>
     </div>


### PR DESCRIPTION
- Apply https://github.com/OpenZeppelin/contracts-wizard/pull/495 to `cairo_alpha` UI
- Fixes extra whitespace in UI before the contract code, due to whitespace in the `<code>` tag which caused it to look like:
![Screenshot 2025-03-28 at 9 27 55 AM](https://github.com/user-attachments/assets/15544cf3-2492-46b4-9643-476a08fd4275)
