### PR TITLE
 Fix Typos in Documentation and Code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ From the root directory:
 
 If linting errors or warnings occur, run `yarn lint --fix` to attempt to auto-fix issues.  If there are remaining issues that cannot be auto-fixed, manually address them and re-run the command to ensure it passes.
 
-### Running formater
+### Running formatter
 From the root directory:
 - ```yarn format:{check|write}```
 

--- a/packages/ui/src/main.ts
+++ b/packages/ui/src/main.ts
@@ -58,7 +58,7 @@ interface IncompatibleSelection {
  * @param requestedVersion The requested version
  * @returns A compatible selection with the app type, or an incompatible selection with the compatible semver range
  */
-function evalutateSelection(
+function evaluateSelection(
   lang: string | undefined,
   requestedVersion: string | undefined,
 ): CompatibleSelection | IncompatibleSelection {
@@ -101,7 +101,7 @@ function evalutateSelection(
 }
 
 let app;
-const selection = evalutateSelection(lang, requestedVersion);
+const selection = evaluateSelection(lang, requestedVersion);
 
 if (!selection.compatible) {
   if (requestedVersion === undefined) {

--- a/packages/ui/src/solidity/App.svelte
+++ b/packages/ui/src/solidity/App.svelte
@@ -130,7 +130,7 @@
     });
   }
 
-  $: showButtons = getButtonVisiblities(opts);
+  $: showButtons = getButtonVisibilities(opts);
 
   interface ButtonVisibilities {
     openInRemix: boolean;
@@ -138,7 +138,7 @@
     downloadFoundry: boolean;
   }
 
-  const getButtonVisiblities = (opts?: KindedOptions[Kind]): ButtonVisibilities => {
+  const getButtonVisibilities = (opts?: KindedOptions[Kind]): ButtonVisibilities => {
     if (opts?.kind === 'Governor') {
       return {
         openInRemix: true,


### PR DESCRIPTION


**Description:**

This pull request addresses several typos found in the documentation and codebase:

1. **CONTRIBUTING.md:**
   - Corrected the spelling of "formater" to "formatter."

2. **packages/ui/src/main.ts:**
   - Fixed the function name from "evalutateSelection" to "evaluateSelection."

3. **packages/ui/src/solidify/App.svelte:**
   - Corrected the function name from "getButtonVisiblities" to "getButtonVisibilities."

These changes improve code readability and maintain consistency across the project.
