### PR TITLE
Add origin referrer for Defender Deploy

### DIFF
--- a/packages/ui/src/solidity/DefenderDeployModal.svelte
+++ b/packages/ui/src/solidity/DefenderDeployModal.svelte
@@ -42,4 +42,5 @@
     ${!showIframe ? 'invisible' : ''} 
     ${!loaded ? 'hidden' : ''}`}
   on:load={handleLoad}
+  referrerpolicy="origin"
 />


### PR DESCRIPTION
Related to https://github.com/OpenZeppelin/defender-deploy-plugin/pull/55

This PR ensures that the referrer origin is always available (without requiring the full URL), including for cross-origin requests.

This isn't strictly needed since browser defaults currently work, but this sets this explicitly since https://github.com/OpenZeppelin/defender-deploy-plugin/pull/55 relies on this use case.