### PR TITLE
Fix typo in comment: "Dissambiguate" -> "Disambiguate"

### DIFF
--- a/packages/core/solidity/src/account.ts
+++ b/packages/core/solidity/src/account.ts
@@ -198,7 +198,7 @@ function overrideRawSignatureValidation(c: ContractBuilder, opts: AccountOptions
     c.setFunctionBody(['// Custom validation logic', 'return false;'], signerFunctions._rawSignatureValidation);
   }
 
-  // Dissambiguate between Signer and AccountERC7579
+  // Disambiguate between Signer and AccountERC7579
   if (opts.signer && opts.ERC7579Modules) {
     c.addImportOnly({
       name: 'AbstractSigner',


### PR DESCRIPTION
Fixed a typo in a comment in account.ts where "Dissambiguate" was incorrectly spelled. Changed to the correct spelling "Disambiguate".

File changed:
- packages/core/solidity/src/account.ts