### PR TITLE
Ignore version workflow if only UI changes present

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'packages/ui/**'
 
 concurrency: version-or-publish-${{ github.ref }}
 


### PR DESCRIPTION
If only the UI package was changed, ignore the version workflow which updates the Prepare Release PR since the core packages don't need to be released.