### PR TITLE
Fix Typo: Change "Dissambiguate" to "Disambiguate" in account.ts

### DIFF
--- a/packages/core/solidity/src/account.ts
+++ b/packages/core/solidity/src/account.ts
@@ -216,7 +216,7 @@ function overrideRawSignatureValidation(c: ContractBuilder, opts: AccountOptions
     c.setFunctionBody(['// Custom validation logic', 'return false;'], signerFunctions._rawSignatureValidation);
   }
 
-  // Dissambiguate between Signer and AccountERC7579
+  // Disambiguate between Signer and AccountERC7579
   if (opts.signer && opts.ERC7579Modules) {
     c.addImportOnly({
       name: 'AbstractSigner',


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the comment within the account.ts file, changing "Dissambiguate" to the correct spelling "Disambiguate" between Signer and AccountERC7579. No functional code changes were made; this update is for clarity and consistency in documentation.
