### PR TITLE
Reorganize readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Contributions to OpenZeppelin Contracts Wizard are welcome. Please review the in
 The following prerequisites are required to build the project locally:
 - [Node.js](https://nodejs.org/)
 - [Yarn](https://yarnpkg.com/getting-started/install)
-- [Deno](https://github.com/denoland/deno?tab=readme-ov-file#installation) to run a local API server for the AI Assistant
+- [Deno](https://github.com/denoland/deno?tab=readme-ov-file#installation) (Optional) to run a local API server for the AI Assistant
   - Note that using the shell installation method is recommended (the `upgrade` command, which allows you to install a specific Deno version, is not always available when installing Deno with other installers).  
   - To install the version of Deno that matches the Netlify deploy environment, run `deno upgrade --version 1.46.3`.
   - When adding dependencies for the Deno app add the dependency as a dev dependency using yarn, map the dependency to the Deno equivalent url in import_map.json and import it like a typescript dependency in the app.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,19 @@ Contracts Wizard is a web application to interactively build a contract out of c
 
 [![](./screenshot.png)](https://wizard.openzeppelin.com/)
 
-## Contributing
+## Usage
 
-See our [contributing guidelines](CONTRIBUTING.md).
+Use the Contracts Wizard at https://wizard.openzeppelin.com/
+
+## TypeScript API
+
+You can use the programmatic TypeScript API to generate contracts from your own applications.
+
+View the API documentation for each smart contract language:
+- [Solidity](packages/core/solidity/README.md)
+- [Cairo](packages/core/cairo/README.md)
+- [Stellar](packages/core/stellar/README.md)
+- [Stylus](packages/core/stylus/README.md)
 
 ## Embedding
 
@@ -28,11 +38,20 @@ Optionally focus on specific tab with the `data-tab` attribute as in `<oz-wizard
 
 For languages other than Solidity, use the `data-lang` attribute, for example: `<oz-wizard data-lang="cairo"></oz-wizard>`.
 
-## API
+## Contributing
 
-The following describes how to use the Contracts Wizard programmatic API in your own applications.
+We welcome contributions from the community! Here's how you can get involved:
 
-- [Contracts Wizard API for Solidity](packages/core/solidity/README.md)
-- [Contracts Wizard API for Cairo](packages/core/cairo/README.md)
-- [Contracts Wizard API for Stellar](packages/core/stellar/README.md)
-- [Contracts Wizard API for Stylus](packages/core/stylus/README.md)
+1. Fork the repository
+2. Create your feature branch
+3. Commit your changes
+4. Push to the branch
+5. Create a Pull Request
+
+If you are looking for a good place to start, find a good first issue [here](https://github.com/openzeppelin/contracts-wizard/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22), or [open an issue](https://github.com/OpenZeppelin/contracts-wizard/issues/new) for a bug report or feature request.
+
+You can find more details in our [Contributing](CONTRIBUTING.md) guide.
+
+## License
+
+This project is licensed under the GNU Affero General Public License v3.0 - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Reorganizes the readme to describe more general usage first, then contribution details and license info to more closely match with our other open source repos.