### PR TITLE
Cairo: Use await async in update-scarb-project

### DIFF
--- a/packages/core/cairo/src/scripts/update-scarb-project.ts
+++ b/packages/core/cairo/src/scripts/update-scarb-project.ts
@@ -47,10 +47,10 @@ export async function updateScarbProject() {
   });
 
   // Generate lib.cairo file
-  writeLibCairo(contractNames);
+  await writeLibCairo(contractNames);
 
   // Update Scarb.toml
-  updateScarbToml();
+  await updateScarbToml();
 }
 
 async function writeLibCairo(contractNames: string[]) {

--- a/packages/core/cairo_alpha/src/scripts/update-scarb-project.ts
+++ b/packages/core/cairo_alpha/src/scripts/update-scarb-project.ts
@@ -47,10 +47,10 @@ export async function updateScarbProject() {
   });
 
   // Generate lib.cairo file
-  writeLibCairo(contractNames);
+  await writeLibCairo(contractNames);
 
   // Update Scarb.toml
-  updateScarbToml();
+  await updateScarbToml();
 }
 
 async function writeLibCairo(contractNames: string[]) {


### PR DESCRIPTION
The async function `updateScarbProject` did not use await when calling other functions.  This causes the script to return while the other functions are still waiting, which leads to race conditions for anything that relies on the script such as the compile cairo project workflows.

Originally reported in https://github.com/OpenZeppelin/contracts-wizard/pull/638#pullrequestreview-3131618650