### PR TITLE
Fix missing dependency for get-versioned-remappings

### DIFF
--- a/.changeset/clear-hoops-joke.md
+++ b/.changeset/clear-hoops-joke.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/wizard': patch
+---
+
+Fix missing dependency for get-versioned-remappings

--- a/packages/core/solidity/.gitignore
+++ b/packages/core/solidity/.gitignore
@@ -2,3 +2,4 @@
 /artifacts
 /contracts/generated
 /openzeppelin-contracts.json
+/openzeppelin-contracts-version.json

--- a/packages/core/solidity/openzeppelin-contracts-version.d.ts
+++ b/packages/core/solidity/openzeppelin-contracts-version.d.ts
@@ -1,0 +1,10 @@
+export interface OpenZeppelinContractsVersion {
+  /**
+   * Version of `@openzeppelin/contracts` and `@openzeppelin/contracts-upgradeable`
+   */
+  version: string;
+}
+
+declare const contractsVersion: OpenZeppelinContractsVersion;
+
+export default contractsVersion;

--- a/packages/core/solidity/package.json
+++ b/packages/core/solidity/package.json
@@ -11,6 +11,8 @@
     "NOTICE",
     "/dist",
     "/src",
+    "openzeppelin-contracts-version.json",
+    "openzeppelin-contracts-version.d.ts",
     "!**/*.test.*"
   ],
   "scripts": {

--- a/packages/core/solidity/src/get-versioned-remappings.ts
+++ b/packages/core/solidity/src/get-versioned-remappings.ts
@@ -1,10 +1,12 @@
 import type { CommonOptions } from './common-options';
-import contracts from '../openzeppelin-contracts';
+import contractsVersion from '../openzeppelin-contracts-version';
 
 export function getVersionedRemappings(opts?: CommonOptions): string[] {
-  const remappings = [`@openzeppelin/contracts/=@openzeppelin/contracts@${contracts.version}/`];
+  const remappings = [`@openzeppelin/contracts/=@openzeppelin/contracts@${contractsVersion.version}/`];
   if (opts?.upgradeable) {
-    remappings.push(`@openzeppelin/contracts-upgradeable/=@openzeppelin/contracts-upgradeable@${contracts.version}/`);
+    remappings.push(
+      `@openzeppelin/contracts-upgradeable/=@openzeppelin/contracts-upgradeable@${contractsVersion.version}/`,
+    );
   }
   return remappings;
 }

--- a/packages/core/solidity/src/package.test.ts
+++ b/packages/core/solidity/src/package.test.ts
@@ -1,0 +1,49 @@
+import test from 'ava';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const execAsync = promisify(exec);
+
+test('packed package can be installed and imported', async t => {
+  const packageRoot = join(__dirname, '..');
+  const tempDir = await mkdtemp(join(tmpdir(), 'wizard-package-test-'));
+
+  try {
+    // Pack the package
+    const { stdout: packOutput } = await execAsync('npm pack', { cwd: packageRoot });
+    // npm pack outputs the filename as the last line
+    const lines = packOutput.trim().split('\n');
+    const packedFile = lines[lines.length - 1]?.trim();
+    if (!packedFile) {
+      throw new Error('Failed to get packed filename from npm pack output');
+    }
+    const packedPath = join(packageRoot, packedFile);
+
+    // Create a test project in temp directory
+    await execAsync('npm init -y', { cwd: tempDir });
+
+    // Install the packed package
+    await execAsync(`npm install "${packedPath}"`, { cwd: tempDir });
+
+    // Test that the package can be imported
+    const testScript = `const { erc20 } = require('@openzeppelin/wizard');
+
+console.log('SUCCESS');
+`;
+
+    const testScriptPath = join(tempDir, 'test.js');
+    await writeFile(testScriptPath, testScript);
+    const { stdout } = await execAsync('node test.js', { cwd: tempDir });
+
+    t.true(stdout.includes('SUCCESS'));
+
+    // Clean up the packed file
+    await rm(packedPath, { force: true });
+  } finally {
+    // Clean up temp directory
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/solidity/src/scripts/prepare.ts
+++ b/packages/core/solidity/src/scripts/prepare.ts
@@ -52,6 +52,9 @@ async function main() {
   };
 
   await fs.writeFile('openzeppelin-contracts.json', JSON.stringify(contracts, null, 2));
+
+  // Generate a separate file with only the version field, to be included in the NPM package
+  await fs.writeFile('openzeppelin-contracts-version.json', JSON.stringify({ version }, null, 2));
 }
 
 main().catch(e => {


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/contracts-wizard/issues/734

Packages a `openzeppelin-contracts-version.json` into the NPM package containing only the version field, instead of using a larger JSON file which was intended for the UI only (and which was missing from the NPM package).

Also adds a packaging test to ensure the package import works.