### PR TITLE
 Align dependency versions in UI package

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "ava": "^6.4.1",
+    "ava": "^6.0.0",
     "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-commonjs": "^28.0.8",
     "@rollup/plugin-json": "^6.1.0",
@@ -21,7 +21,7 @@
     "@rollup/plugin-replace": "^6.0.2",
     "@rollup/plugin-typescript": "^12.1.4",
     "@types/file-saver": "^2.0.7",
-    "@types/node": "^20.19.21",
+    "@types/node": "^20.0.0",
     "@types/resize-observer-browser": "^0.1.11",
     "@types/semver": "^7.7.1",
     "@upstash/redis": "1.35.6",
@@ -41,14 +41,14 @@
     "tailwindcss": "^3.4.18",
     "tslib": "^2.8.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.0.0"
   },
   "dependencies": {
     "file-saver": "^2.0.5",
     "highlight.js": "^11.11.1",
     "highlightjs-cairo": "^0.4.0",
     "highlightjs-solidity": "^2.0.6",
-    "semver": "^7.7.3",
+    "semver": "^7.6.0",
     "sirv-cli": "^3.0.1",
     "tippy.js": "^6.3.7",
     "util": "^0.12.5"


### PR DESCRIPTION
## Summary
  Aligns 4 dependency versions in `packages/ui` to match the rest of the monorepo.

  ## Changes
  - `ava`: ^6.4.1 → ^6.0.0 (7 other packages use ^6.0.0)
  - `@types/node`: ^20.19.21 → ^20.0.0 (7 other packages use ^20.0.0)
  - `typescript`: ^5.9.3 → ^5.0.0 (majority of packages use ^5.0.0)
  - `semver`: ^7.7.3 → ^7.6.0 (core packages use ^7.6.0)