### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Contracts Wizard is a web application to interactively build a contract out of c
 
 [![](./screenshot.png)](https://wizard.openzeppelin.com)
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/openzeppelin-contracts-wizard).
+
 ## Usage
 
 Use the Contracts Wizard at https://wizard.openzeppelin.com


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/openzeppelin-contracts-wizard)