### PR TITLE
Use Node 24 for publish and fix OIDC auth handling

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,11 +1,16 @@
 name: Setup
 
+inputs:
+  node-version:
+    description: Node.js version to use
+    default: '22'
+
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: 22
+        node-version: ${{ inputs.node-version }}
         cache: yarn
         registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,8 @@ jobs:
           ref: ${{ github.ref }}
       - name: Set up environment
         uses: ./.github/actions/setup
-      - name: Install npm 11 for OIDC trusted publishing
-        run: npm install -g npm@11.12.1
+        with:
+          node-version: '24'
       - name: Check for new packages
         id: check-packages
         run: |
@@ -61,10 +61,15 @@ jobs:
             echo "All packages exist on npm — using OIDC trusted publishing"
           fi
           echo "has_new_packages=$has_new_packages" >> "$GITHUB_OUTPUT"
-      - name: Enable NPM token publishing
-        if: steps.check-packages.outputs.has_new_packages == 'true'
-        run: echo "NODE_AUTH_TOKEN=${NPM_TOKEN}" >> "$GITHUB_ENV"
+      - name: Configure npm auth
+        run: |
+          if [ "$HAS_NEW_PACKAGES" = "true" ]; then
+            echo "NODE_AUTH_TOKEN=${NPM_TOKEN}" >> "$GITHUB_ENV"
+          else
+            echo "NODE_AUTH_TOKEN=" >> "$GITHUB_ENV"
+          fi
         env:
+          HAS_NEW_PACKAGES: ${{ steps.check-packages.outputs.has_new_packages }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Prepare Release PR or Publish
         id: changesets

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+  unset NODE_AUTH_TOKEN
+fi
+
 yarn install --frozen-lockfile
 changeset publish
 git push --follow-tags


### PR DESCRIPTION
- Use Node 24 (which ships with npm 11) instead of installing npm 11 globally, fixing a self-upgrade MODULE_NOT_FOUND failure.
- Explicitly clear `NODE_AUTH_TOKEN` on the OIDC path to prevent setup-node's injected token from blocking trusted publishing.
- Parameterize the setup action's node-version and bump setup-node to v6.3.0.