### PR TITLE
Fix OIDC publish by stripping _authToken from .npmrc

### DIFF
--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 
 if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
   unset NODE_AUTH_TOKEN
+  # OIDC trusted publishing authenticates via short-lived OIDC tokens, so the
+  # .npmrc must not declare an _authToken. Strip the line that actions/setup-node
+  # wrote so yarn parses a clean config and npm falls through to the OIDC flow.
+  if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+    sed -i '/_authToken=/d' "$NPM_CONFIG_USERCONFIG"
+  fi
 fi
 
 yarn install --frozen-lockfile


### PR DESCRIPTION
Fixes the release workflow's OIDC trusted publishing path so it can authenticate without an `NPM_TOKEN`.

`actions/setup-node` writes `_authToken=${NODE_AUTH_TOKEN}` into `.npmrc`. In OIDC mode that variable is unset, and yarn errors when it tries to substitute it. This strips the `_authToken` line before yarn runs, leaving a clean config for OIDC to work with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)