### PR TITLE
Reject line terminators in info.securityContact and info.license

### DIFF
--- a/.changeset/quick-spiders-cheer.md
+++ b/.changeset/quick-spiders-cheer.md
@@ -5,4 +5,4 @@
 '@openzeppelin/wizard-stylus': patch
 ---
 
-Reject line terminators in `info.securityContact` and `info.license` to prevent breaking out of the generated comment lines.
+Reject line terminators in `info.securityContact` and `info.license` to prevent breaking out of the generated comment lines. Fixes [GHSA-9wxg-vf3r-56hc](https://github.com/OpenZeppelin/contracts-wizard/security/advisories/GHSA-9wxg-vf3r-56hc).

--- a/.changeset/quick-spiders-cheer.md
+++ b/.changeset/quick-spiders-cheer.md
@@ -1,0 +1,8 @@
+---
+'@openzeppelin/wizard': patch
+'@openzeppelin/wizard-cairo': patch
+'@openzeppelin/wizard-stellar': patch
+'@openzeppelin/wizard-stylus': patch
+---
+
+Reject line terminators in `info.securityContact` and `info.license` to prevent breaking out of the generated comment lines.

--- a/packages/core/cairo/src/set-info.test.ts
+++ b/packages/core/cairo/src/set-info.test.ts
@@ -11,9 +11,6 @@ const lineBreaks: [string, string][] = [
   ['CRLF', '\r\n'],
   ['LS', '\u2028'],
   ['PS', '\u2029'],
-  ['NEL', '\u0085'],
-  ['VT', '\v'],
-  ['FF', '\f'],
 ];
 
 for (const [name, ch] of lineBreaks) {

--- a/packages/core/cairo/src/set-info.test.ts
+++ b/packages/core/cairo/src/set-info.test.ts
@@ -1,0 +1,36 @@
+import test from 'ava';
+
+import { ContractBuilder } from './contract';
+import { defaults as macrosDefaults } from './set-macros';
+import { setInfo } from './set-info';
+import type { OptionsError } from './error';
+
+const lineBreaks: [string, string][] = [
+  ['LF', '\n'],
+  ['CR', '\r'],
+  ['CRLF', '\r\n'],
+  ['LS', '\u2028'],
+  ['PS', '\u2029'],
+  ['NEL', '\u0085'],
+  ['VT', '\v'],
+  ['FF', '\f'],
+];
+
+for (const [name, ch] of lineBreaks) {
+  test(`setInfo rejects ${name} in securityContact`, t => {
+    const c = new ContractBuilder('MyContract', macrosDefaults);
+    const error = t.throws(() => setInfo(c, { securityContact: `security@example.com${ch}mod injected {}` }));
+    t.is((error as OptionsError).messages.securityContact, 'Must not contain line breaks');
+  });
+
+  test(`setInfo rejects ${name} in license`, t => {
+    const c = new ContractBuilder('MyContract', macrosDefaults);
+    const error = t.throws(() => setInfo(c, { license: `MIT${ch}mod injected {}` }));
+    t.is((error as OptionsError).messages.license, 'Must not contain line breaks');
+  });
+}
+
+test('setInfo accepts valid single-line values', t => {
+  const c = new ContractBuilder('MyContract', macrosDefaults);
+  t.notThrows(() => setInfo(c, { securityContact: 'security@example.com', license: 'MIT' }));
+});

--- a/packages/core/cairo/src/set-info.ts
+++ b/packages/core/cairo/src/set-info.ts
@@ -3,10 +3,11 @@ import { OptionsError } from './error';
 
 export const SECURITY_CONTACT_DOCUMENTATION = `Security contact: `;
 
-// Line terminators (and characters that source lexers may treat as such).
-// These are disallowed in single-line metadata fields so an embedded line
-// break cannot escape the generated SPDX/comment line and inject source.
-const LINE_TERMINATOR = /[\n\r\u2028\u2029\u0085\v\f]/u;
+// These values are printed into a // comment line in the generated Cairo. LF
+// ends that comment, letting following text become source. CR and U+2028/U+2029
+// are rejected as defense in depth (review tools render U+2028/U+2029 as line
+// breaks).
+const LINE_TERMINATOR = /[\n\r\u2028\u2029]/u;
 
 function checkSingleLine(value: string, field: string): void {
   if (LINE_TERMINATOR.test(value)) {

--- a/packages/core/cairo/src/set-info.ts
+++ b/packages/core/cairo/src/set-info.ts
@@ -1,6 +1,18 @@
 import type { ContractBuilder } from './contract';
+import { OptionsError } from './error';
 
 export const SECURITY_CONTACT_DOCUMENTATION = `Security contact: `;
+
+// Line terminators (and characters that source lexers may treat as such).
+// These are disallowed in single-line metadata fields so an embedded line
+// break cannot escape the generated SPDX/comment line and inject source.
+const LINE_TERMINATOR = /[\n\r\u2028\u2029\u0085\v\f]/u;
+
+function checkSingleLine(value: string, field: string): void {
+  if (LINE_TERMINATOR.test(value)) {
+    throw new OptionsError({ [field]: 'Must not contain line breaks' });
+  }
+}
 
 export const infoOptions = [{}, { license: 'WTFPL' }] as const;
 
@@ -15,10 +27,12 @@ export function setInfo(c: ContractBuilder, info: Info): void {
   const { securityContact, license } = info;
 
   if (securityContact) {
+    checkSingleLine(securityContact, 'securityContact');
     c.addDocumentation(`${SECURITY_CONTACT_DOCUMENTATION}${securityContact}`);
   }
 
   if (license) {
+    checkSingleLine(license, 'license');
     c.license = license;
   }
 }

--- a/packages/core/cairo_alpha/src/set-info.test.ts
+++ b/packages/core/cairo_alpha/src/set-info.test.ts
@@ -11,9 +11,6 @@ const lineBreaks: [string, string][] = [
   ['CRLF', '\r\n'],
   ['LS', '\u2028'],
   ['PS', '\u2029'],
-  ['NEL', '\u0085'],
-  ['VT', '\v'],
-  ['FF', '\f'],
 ];
 
 for (const [name, ch] of lineBreaks) {

--- a/packages/core/cairo_alpha/src/set-info.test.ts
+++ b/packages/core/cairo_alpha/src/set-info.test.ts
@@ -1,0 +1,36 @@
+import test from 'ava';
+
+import { ContractBuilder } from './contract';
+import { defaults as macrosDefaults } from './set-macros';
+import { setInfo } from './set-info';
+import type { OptionsError } from './error';
+
+const lineBreaks: [string, string][] = [
+  ['LF', '\n'],
+  ['CR', '\r'],
+  ['CRLF', '\r\n'],
+  ['LS', '\u2028'],
+  ['PS', '\u2029'],
+  ['NEL', '\u0085'],
+  ['VT', '\v'],
+  ['FF', '\f'],
+];
+
+for (const [name, ch] of lineBreaks) {
+  test(`setInfo rejects ${name} in securityContact`, t => {
+    const c = new ContractBuilder('MyContract', macrosDefaults);
+    const error = t.throws(() => setInfo(c, { securityContact: `security@example.com${ch}mod injected {}` }));
+    t.is((error as OptionsError).messages.securityContact, 'Must not contain line breaks');
+  });
+
+  test(`setInfo rejects ${name} in license`, t => {
+    const c = new ContractBuilder('MyContract', macrosDefaults);
+    const error = t.throws(() => setInfo(c, { license: `MIT${ch}mod injected {}` }));
+    t.is((error as OptionsError).messages.license, 'Must not contain line breaks');
+  });
+}
+
+test('setInfo accepts valid single-line values', t => {
+  const c = new ContractBuilder('MyContract', macrosDefaults);
+  t.notThrows(() => setInfo(c, { securityContact: 'security@example.com', license: 'MIT' }));
+});

--- a/packages/core/cairo_alpha/src/set-info.ts
+++ b/packages/core/cairo_alpha/src/set-info.ts
@@ -3,10 +3,11 @@ import { OptionsError } from './error';
 
 export const SECURITY_CONTACT_DOCUMENTATION = `Security contact: `;
 
-// Line terminators (and characters that source lexers may treat as such).
-// These are disallowed in single-line metadata fields so an embedded line
-// break cannot escape the generated SPDX/comment line and inject source.
-const LINE_TERMINATOR = /[\n\r\u2028\u2029\u0085\v\f]/u;
+// These values are printed into a // comment line in the generated Cairo. LF
+// ends that comment, letting following text become source. CR and U+2028/U+2029
+// are rejected as defense in depth (review tools render U+2028/U+2029 as line
+// breaks).
+const LINE_TERMINATOR = /[\n\r\u2028\u2029]/u;
 
 function checkSingleLine(value: string, field: string): void {
   if (LINE_TERMINATOR.test(value)) {

--- a/packages/core/cairo_alpha/src/set-info.ts
+++ b/packages/core/cairo_alpha/src/set-info.ts
@@ -1,6 +1,18 @@
 import type { ContractBuilder } from './contract';
+import { OptionsError } from './error';
 
 export const SECURITY_CONTACT_DOCUMENTATION = `Security contact: `;
+
+// Line terminators (and characters that source lexers may treat as such).
+// These are disallowed in single-line metadata fields so an embedded line
+// break cannot escape the generated SPDX/comment line and inject source.
+const LINE_TERMINATOR = /[\n\r\u2028\u2029\u0085\v\f]/u;
+
+function checkSingleLine(value: string, field: string): void {
+  if (LINE_TERMINATOR.test(value)) {
+    throw new OptionsError({ [field]: 'Must not contain line breaks' });
+  }
+}
 
 export const infoOptions = [{}, { license: 'WTFPL' }] as const;
 
@@ -15,10 +27,12 @@ export function setInfo(c: ContractBuilder, info: Info): void {
   const { securityContact, license } = info;
 
   if (securityContact) {
+    checkSingleLine(securityContact, 'securityContact');
     c.addDocumentation(`${SECURITY_CONTACT_DOCUMENTATION}${securityContact}`);
   }
 
   if (license) {
+    checkSingleLine(license, 'license');
     c.license = license;
   }
 }

--- a/packages/core/solidity/src/set-info.test.ts
+++ b/packages/core/solidity/src/set-info.test.ts
@@ -1,0 +1,35 @@
+import test from 'ava';
+
+import { ContractBuilder } from './contract';
+import { setInfo } from './set-info';
+import type { OptionsError } from './error';
+
+const lineBreaks: [string, string][] = [
+  ['LF', '\n'],
+  ['CR', '\r'],
+  ['CRLF', '\r\n'],
+  ['LS', '\u2028'],
+  ['PS', '\u2029'],
+  ['NEL', '\u0085'],
+  ['VT', '\v'],
+  ['FF', '\f'],
+];
+
+for (const [name, ch] of lineBreaks) {
+  test(`setInfo rejects ${name} in securityContact`, t => {
+    const c = new ContractBuilder('MyContract');
+    const error = t.throws(() => setInfo(c, { securityContact: `security@example.com${ch}contract Injected {}` }));
+    t.is((error as OptionsError).messages.securityContact, 'Must not contain line breaks');
+  });
+
+  test(`setInfo rejects ${name} in license`, t => {
+    const c = new ContractBuilder('MyContract');
+    const error = t.throws(() => setInfo(c, { license: `MIT${ch}contract Injected {}` }));
+    t.is((error as OptionsError).messages.license, 'Must not contain line breaks');
+  });
+}
+
+test('setInfo accepts valid single-line values', t => {
+  const c = new ContractBuilder('MyContract');
+  t.notThrows(() => setInfo(c, { securityContact: 'security@example.com', license: 'MIT' }));
+});

--- a/packages/core/solidity/src/set-info.test.ts
+++ b/packages/core/solidity/src/set-info.test.ts
@@ -10,9 +10,6 @@ const lineBreaks: [string, string][] = [
   ['CRLF', '\r\n'],
   ['LS', '\u2028'],
   ['PS', '\u2029'],
-  ['NEL', '\u0085'],
-  ['VT', '\v'],
-  ['FF', '\f'],
 ];
 
 for (const [name, ch] of lineBreaks) {

--- a/packages/core/solidity/src/set-info.ts
+++ b/packages/core/solidity/src/set-info.ts
@@ -1,6 +1,18 @@
 import type { ContractBuilder } from './contract';
+import { OptionsError } from './error';
 
 export const TAG_SECURITY_CONTACT = `@custom:security-contact`;
+
+// Line terminators (and characters that source lexers may treat as such).
+// These are disallowed in single-line metadata fields so an embedded line
+// break cannot escape the generated SPDX/comment line and inject source.
+const LINE_TERMINATOR = /[\n\r\u2028\u2029\u0085\v\f]/u;
+
+function checkSingleLine(value: string, field: string): void {
+  if (LINE_TERMINATOR.test(value)) {
+    throw new OptionsError({ [field]: 'Must not contain line breaks' });
+  }
+}
 
 export const infoOptions = [{}, { securityContact: 'security@example.com', license: 'WTFPL' }] as const;
 
@@ -15,10 +27,12 @@ export function setInfo(c: ContractBuilder, info: Info) {
   const { securityContact, license } = info;
 
   if (securityContact) {
+    checkSingleLine(securityContact, 'securityContact');
     c.addNatspecTag(TAG_SECURITY_CONTACT, securityContact);
   }
 
   if (license) {
+    checkSingleLine(license, 'license');
     c.license = license;
   }
 }

--- a/packages/core/solidity/src/set-info.ts
+++ b/packages/core/solidity/src/set-info.ts
@@ -3,10 +3,11 @@ import { OptionsError } from './error';
 
 export const TAG_SECURITY_CONTACT = `@custom:security-contact`;
 
-// Line terminators (and characters that source lexers may treat as such).
-// These are disallowed in single-line metadata fields so an embedded line
-// break cannot escape the generated SPDX/comment line and inject source.
-const LINE_TERMINATOR = /[\n\r\u2028\u2029\u0085\v\f]/u;
+// LF and CR end a line comment in solc, letting following text escape the
+// generated comment line and become source. U+2028/U+2029 are also rejected:
+// solc errors on them, and review tools render them as line breaks. Other
+// control chars (VT/FF/NEL) error in solc too but cannot silently inject.
+const LINE_TERMINATOR = /[\n\r\u2028\u2029]/u;
 
 function checkSingleLine(value: string, field: string): void {
   if (LINE_TERMINATOR.test(value)) {

--- a/packages/core/stellar/src/set-info.test.ts
+++ b/packages/core/stellar/src/set-info.test.ts
@@ -1,0 +1,35 @@
+import test from 'ava';
+
+import { ContractBuilder } from './contract';
+import { setInfo } from './set-info';
+import type { OptionsError } from './error';
+
+const lineBreaks: [string, string][] = [
+  ['LF', '\n'],
+  ['CR', '\r'],
+  ['CRLF', '\r\n'],
+  ['LS', '\u2028'],
+  ['PS', '\u2029'],
+  ['NEL', '\u0085'],
+  ['VT', '\v'],
+  ['FF', '\f'],
+];
+
+for (const [name, ch] of lineBreaks) {
+  test(`setInfo rejects ${name} in securityContact`, t => {
+    const c = new ContractBuilder('MyContract');
+    const error = t.throws(() => setInfo(c, { securityContact: `security@example.com${ch}contract Injected {}` }));
+    t.is((error as OptionsError).messages.securityContact, 'Must not contain line breaks');
+  });
+
+  test(`setInfo rejects ${name} in license`, t => {
+    const c = new ContractBuilder('MyContract');
+    const error = t.throws(() => setInfo(c, { license: `MIT${ch}contract Injected {}` }));
+    t.is((error as OptionsError).messages.license, 'Must not contain line breaks');
+  });
+}
+
+test('setInfo accepts valid single-line values', t => {
+  const c = new ContractBuilder('MyContract');
+  t.notThrows(() => setInfo(c, { securityContact: 'security@example.com', license: 'MIT' }));
+});

--- a/packages/core/stellar/src/set-info.test.ts
+++ b/packages/core/stellar/src/set-info.test.ts
@@ -10,9 +10,6 @@ const lineBreaks: [string, string][] = [
   ['CRLF', '\r\n'],
   ['LS', '\u2028'],
   ['PS', '\u2029'],
-  ['NEL', '\u0085'],
-  ['VT', '\v'],
-  ['FF', '\f'],
 ];
 
 for (const [name, ch] of lineBreaks) {

--- a/packages/core/stellar/src/set-info.ts
+++ b/packages/core/stellar/src/set-info.ts
@@ -1,10 +1,11 @@
 import type { ContractBuilder } from './contract';
 import { OptionsError } from './error';
 
-// Line terminators (and characters that source lexers may treat as such).
-// These are disallowed in single-line metadata fields so an embedded line
-// break cannot escape the generated SPDX/comment line and inject source.
-const LINE_TERMINATOR = /[\n\r\u2028\u2029\u0085\v\f]/u;
+// These values are printed into a // comment line in the generated Rust. LF
+// ends that comment, letting following text become source. CR and U+2028/U+2029
+// cannot break out in Rust, but are rejected as defense in depth (review tools
+// render U+2028/U+2029 as line breaks).
+const LINE_TERMINATOR = /[\n\r\u2028\u2029]/u;
 
 function checkSingleLine(value: string, field: string): void {
   if (LINE_TERMINATOR.test(value)) {

--- a/packages/core/stellar/src/set-info.ts
+++ b/packages/core/stellar/src/set-info.ts
@@ -1,4 +1,16 @@
 import type { ContractBuilder } from './contract';
+import { OptionsError } from './error';
+
+// Line terminators (and characters that source lexers may treat as such).
+// These are disallowed in single-line metadata fields so an embedded line
+// break cannot escape the generated SPDX/comment line and inject source.
+const LINE_TERMINATOR = /[\n\r\u2028\u2029\u0085\v\f]/u;
+
+function checkSingleLine(value: string, field: string): void {
+  if (LINE_TERMINATOR.test(value)) {
+    throw new OptionsError({ [field]: 'Must not contain line breaks' });
+  }
+}
 
 export const infoOptions = [{}, { license: 'WTFPL' }] as const;
 
@@ -10,7 +22,13 @@ export type Info = {
 };
 
 export function setInfo(c: ContractBuilder, { securityContact, license }: Info): void {
-  if (securityContact) c.addContractMetadata({ key: 'security_contact', value: securityContact });
+  if (securityContact) {
+    checkSingleLine(securityContact, 'securityContact');
+    c.addContractMetadata({ key: 'security_contact', value: securityContact });
+  }
 
-  if (license) c.license = license;
+  if (license) {
+    checkSingleLine(license, 'license');
+    c.license = license;
+  }
 }

--- a/packages/core/stylus/src/set-info.test.ts
+++ b/packages/core/stylus/src/set-info.test.ts
@@ -1,0 +1,35 @@
+import test from 'ava';
+
+import { ContractBuilder } from './contract';
+import { setInfo } from './set-info';
+import type { OptionsError } from './error';
+
+const lineBreaks: [string, string][] = [
+  ['LF', '\n'],
+  ['CR', '\r'],
+  ['CRLF', '\r\n'],
+  ['LS', '\u2028'],
+  ['PS', '\u2029'],
+  ['NEL', '\u0085'],
+  ['VT', '\v'],
+  ['FF', '\f'],
+];
+
+for (const [name, ch] of lineBreaks) {
+  test(`setInfo rejects ${name} in securityContact`, t => {
+    const c = new ContractBuilder('MyContract');
+    const error = t.throws(() => setInfo(c, { securityContact: `security@example.com${ch}contract Injected {}` }));
+    t.is((error as OptionsError).messages.securityContact, 'Must not contain line breaks');
+  });
+
+  test(`setInfo rejects ${name} in license`, t => {
+    const c = new ContractBuilder('MyContract');
+    const error = t.throws(() => setInfo(c, { license: `MIT${ch}contract Injected {}` }));
+    t.is((error as OptionsError).messages.license, 'Must not contain line breaks');
+  });
+}
+
+test('setInfo accepts valid single-line values', t => {
+  const c = new ContractBuilder('MyContract');
+  t.notThrows(() => setInfo(c, { securityContact: 'security@example.com', license: 'MIT' }));
+});

--- a/packages/core/stylus/src/set-info.test.ts
+++ b/packages/core/stylus/src/set-info.test.ts
@@ -10,9 +10,6 @@ const lineBreaks: [string, string][] = [
   ['CRLF', '\r\n'],
   ['LS', '\u2028'],
   ['PS', '\u2029'],
-  ['NEL', '\u0085'],
-  ['VT', '\v'],
-  ['FF', '\f'],
 ];
 
 for (const [name, ch] of lineBreaks) {

--- a/packages/core/stylus/src/set-info.ts
+++ b/packages/core/stylus/src/set-info.ts
@@ -1,10 +1,11 @@
 import type { ContractBuilder } from './contract';
 import { OptionsError } from './error';
 
-// Line terminators (and characters that source lexers may treat as such).
-// These are disallowed in single-line metadata fields so an embedded line
-// break cannot escape the generated SPDX/comment line and inject source.
-const LINE_TERMINATOR = /[\n\r\u2028\u2029\u0085\v\f]/u;
+// These values are printed into a // comment line in the generated Rust. LF
+// ends that comment, letting following text become source. CR and U+2028/U+2029
+// cannot break out in Rust, but are rejected as defense in depth (review tools
+// render U+2028/U+2029 as line breaks).
+const LINE_TERMINATOR = /[\n\r\u2028\u2029]/u;
 
 function checkSingleLine(value: string, field: string): void {
   if (LINE_TERMINATOR.test(value)) {

--- a/packages/core/stylus/src/set-info.ts
+++ b/packages/core/stylus/src/set-info.ts
@@ -1,4 +1,16 @@
 import type { ContractBuilder } from './contract';
+import { OptionsError } from './error';
+
+// Line terminators (and characters that source lexers may treat as such).
+// These are disallowed in single-line metadata fields so an embedded line
+// break cannot escape the generated SPDX/comment line and inject source.
+const LINE_TERMINATOR = /[\n\r\u2028\u2029\u0085\v\f]/u;
+
+function checkSingleLine(value: string, field: string): void {
+  if (LINE_TERMINATOR.test(value)) {
+    throw new OptionsError({ [field]: 'Must not contain line breaks' });
+  }
+}
 
 export const infoOptions = [{}, { license: 'WTFPL' }] as const;
 
@@ -13,10 +25,12 @@ export function setInfo(c: ContractBuilder, info: Info): void {
   const { securityContact, license } = info;
 
   if (securityContact) {
+    checkSingleLine(securityContact, 'securityContact');
     c.addSecurityTag(securityContact);
   }
 
   if (license) {
+    checkSingleLine(license, 'license');
     c.license = license;
   }
 }

--- a/packages/ui/src/cairo/AccountControls.svelte
+++ b/packages/ui/src/cairo/AccountControls.svelte
@@ -87,4 +87,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo/CustomControls.svelte
+++ b/packages/ui/src/cairo/CustomControls.svelte
@@ -61,4 +61,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo/ERC1155Controls.svelte
+++ b/packages/ui/src/cairo/ERC1155Controls.svelte
@@ -90,4 +90,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo/ERC20Controls.svelte
+++ b/packages/ui/src/cairo/ERC20Controls.svelte
@@ -128,4 +128,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo/ERC721Controls.svelte
+++ b/packages/ui/src/cairo/ERC721Controls.svelte
@@ -126,4 +126,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo/GovernorControls.svelte
+++ b/packages/ui/src/cairo/GovernorControls.svelte
@@ -242,4 +242,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo/InfoSection.svelte
+++ b/packages/ui/src/cairo/InfoSection.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
-  import type { Info } from '@openzeppelin/wizard-cairo';
+  import type { Info, OptionsErrorMessages } from '@openzeppelin/wizard-cairo';
   import { infoDefaults } from '@openzeppelin/wizard-cairo';
   import HelpTooltip from '../common/HelpTooltip.svelte';
+  import { error } from '../common/error-tooltip';
 
   export let info: Info;
+
+  export let errors: OptionsErrorMessages | undefined = undefined;
 </script>
 
 <section class="controls-section">
@@ -21,11 +24,11 @@
         Where people can contact you to report security issues. Will only be visible if contract metadata is verified.
       </HelpTooltip>
     </span>
-    <input bind:value={info.securityContact} placeholder="security@example.com" />
+    <input bind:value={info.securityContact} placeholder="security@example.com" use:error={errors?.securityContact} />
   </label>
 
   <label class="labeled-input">
     <span>License</span>
-    <input bind:value={info.license} placeholder={infoDefaults.license} />
+    <input bind:value={info.license} placeholder={infoDefaults.license} use:error={errors?.license} />
   </label>
 </section>

--- a/packages/ui/src/cairo/MultisigControls.svelte
+++ b/packages/ui/src/cairo/MultisigControls.svelte
@@ -49,4 +49,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo/VestingControls.svelte
+++ b/packages/ui/src/cairo/VestingControls.svelte
@@ -75,4 +75,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo_alpha/AccountControls.svelte
+++ b/packages/ui/src/cairo_alpha/AccountControls.svelte
@@ -87,4 +87,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo_alpha/CustomControls.svelte
+++ b/packages/ui/src/cairo_alpha/CustomControls.svelte
@@ -61,4 +61,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo_alpha/ERC1155Controls.svelte
+++ b/packages/ui/src/cairo_alpha/ERC1155Controls.svelte
@@ -100,4 +100,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo_alpha/ERC20Controls.svelte
+++ b/packages/ui/src/cairo_alpha/ERC20Controls.svelte
@@ -137,4 +137,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo_alpha/ERC6909Controls.svelte
+++ b/packages/ui/src/cairo_alpha/ERC6909Controls.svelte
@@ -91,4 +91,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo_alpha/ERC721Controls.svelte
+++ b/packages/ui/src/cairo_alpha/ERC721Controls.svelte
@@ -149,4 +149,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo_alpha/GovernorControls.svelte
+++ b/packages/ui/src/cairo_alpha/GovernorControls.svelte
@@ -244,4 +244,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo_alpha/InfoSection.svelte
+++ b/packages/ui/src/cairo_alpha/InfoSection.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
-  import type { Info } from '@openzeppelin/wizard-cairo-alpha';
+  import type { Info, OptionsErrorMessages } from '@openzeppelin/wizard-cairo-alpha';
   import { infoDefaults } from '@openzeppelin/wizard-cairo-alpha';
   import HelpTooltip from '../common/HelpTooltip.svelte';
+  import { error } from '../common/error-tooltip';
 
   export let info: Info;
+
+  export let errors: OptionsErrorMessages | undefined = undefined;
 </script>
 
 <section class="controls-section">
@@ -21,11 +24,11 @@
         Where people can contact you to report security issues. Will only be visible if contract metadata is verified.
       </HelpTooltip>
     </span>
-    <input bind:value={info.securityContact} placeholder="security@example.com" />
+    <input bind:value={info.securityContact} placeholder="security@example.com" use:error={errors?.securityContact} />
   </label>
 
   <label class="labeled-input">
     <span>License</span>
-    <input bind:value={info.license} placeholder={infoDefaults.license} />
+    <input bind:value={info.license} placeholder={infoDefaults.license} use:error={errors?.license} />
   </label>
 </section>

--- a/packages/ui/src/cairo_alpha/MultisigControls.svelte
+++ b/packages/ui/src/cairo_alpha/MultisigControls.svelte
@@ -49,4 +49,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/cairo_alpha/VestingControls.svelte
+++ b/packages/ui/src/cairo_alpha/VestingControls.svelte
@@ -75,4 +75,4 @@
 
 <MacrosSection bind:macros={opts.macros} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/confidential/ERC7984Controls.svelte
+++ b/packages/ui/src/confidential/ERC7984Controls.svelte
@@ -146,4 +146,4 @@
   </div>
 </ExpandableToggleRadio>
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/solidity/AccountControls.svelte
+++ b/packages/ui/src/solidity/AccountControls.svelte
@@ -232,4 +232,4 @@
   disabledReason={upgradeNotSupportedReason}
 />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/solidity/App.svelte
+++ b/packages/ui/src/solidity/App.svelte
@@ -356,7 +356,7 @@
         <ERC721Controls bind:opts={allOpts.ERC721} errors={errors.ERC721} />
       </div>
       <div class:hidden={tab !== 'ERC1155'}>
-        <ERC1155Controls bind:opts={allOpts.ERC1155} />
+        <ERC1155Controls bind:opts={allOpts.ERC1155} errors={errors.ERC1155} />
       </div>
       <div class:hidden={tab !== 'Stablecoin'}>
         <StablecoinControls
@@ -379,7 +379,7 @@
         <GovernorControls bind:opts={allOpts.Governor} errors={errors.Governor} />
       </div>
       <div class:hidden={tab !== 'Custom'}>
-        <CustomControls bind:opts={allOpts.Custom} />
+        <CustomControls bind:opts={allOpts.Custom} errors={errors.Custom} />
       </div>
     </div>
 

--- a/packages/ui/src/solidity/CustomControls.svelte
+++ b/packages/ui/src/solidity/CustomControls.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import HelpTooltip from '../common/HelpTooltip.svelte';
 
-  import type { KindedOptions } from '@openzeppelin/wizard';
+  import type { KindedOptions, OptionsErrorMessages } from '@openzeppelin/wizard';
   import { custom, infoDefaults } from '@openzeppelin/wizard';
 
   import AccessControlSection from './AccessControlSection.svelte';
@@ -13,6 +13,8 @@
     ...custom.defaults,
     info: { ...infoDefaults }, // create new object since Info is nested
   };
+
+  export let errors: undefined | OptionsErrorMessages;
 
   $: requireAccessControl = custom.isAccessControlRequired(opts);
 </script>
@@ -45,4 +47,4 @@
 
 <UpgradeabilitySection bind:upgradeable={opts.upgradeable} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/solidity/ERC1155Controls.svelte
+++ b/packages/ui/src/solidity/ERC1155Controls.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import HelpTooltip from '../common/HelpTooltip.svelte';
 
-  import type { KindedOptions } from '@openzeppelin/wizard';
+  import type { KindedOptions, OptionsErrorMessages } from '@openzeppelin/wizard';
   import { erc1155, infoDefaults } from '@openzeppelin/wizard';
 
   import AccessControlSection from './AccessControlSection.svelte';
@@ -13,6 +13,8 @@
     ...erc1155.defaults,
     info: { ...infoDefaults }, // create new object since Info is nested
   };
+
+  export let errors: undefined | OptionsErrorMessages;
 
   $: requireAccessControl = erc1155.isAccessControlRequired(opts);
 </script>
@@ -79,4 +81,4 @@
 
 <UpgradeabilitySection bind:upgradeable={opts.upgradeable} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/solidity/ERC20Controls.svelte
+++ b/packages/ui/src/solidity/ERC20Controls.svelte
@@ -240,4 +240,4 @@
   {errors}
 />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/solidity/ERC721Controls.svelte
+++ b/packages/ui/src/solidity/ERC721Controls.svelte
@@ -138,4 +138,4 @@
   {errors}
 />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/solidity/GovernorControls.svelte
+++ b/packages/ui/src/solidity/GovernorControls.svelte
@@ -257,4 +257,4 @@
 
 <UpgradeabilitySection bind:upgradeable={opts.upgradeable} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/solidity/InfoSection.svelte
+++ b/packages/ui/src/solidity/InfoSection.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-  import type { Info } from '@openzeppelin/wizard';
+  import type { Info, OptionsErrorMessages } from '@openzeppelin/wizard';
   import { infoDefaults } from '@openzeppelin/wizard';
 
   import HelpTooltip from '../common/HelpTooltip.svelte';
+  import { error } from '../common/error-tooltip';
 
   export let info: Info;
+
+  export let errors: OptionsErrorMessages | undefined = undefined;
 </script>
 
 <section class="controls-section">
@@ -22,11 +25,11 @@
         Where people can contact you to report security issues. Will only be visible if contract metadata is verified.
       </HelpTooltip>
     </span>
-    <input bind:value={info.securityContact} placeholder="security@example.com" />
+    <input bind:value={info.securityContact} placeholder="security@example.com" use:error={errors?.securityContact} />
   </label>
 
   <label class="labeled-input">
     <span>License</span>
-    <input bind:value={info.license} placeholder={infoDefaults.license} />
+    <input bind:value={info.license} placeholder={infoDefaults.license} use:error={errors?.license} />
   </label>
 </section>

--- a/packages/ui/src/solidity/RealWorldAssetControls.svelte
+++ b/packages/ui/src/solidity/RealWorldAssetControls.svelte
@@ -274,4 +274,4 @@
 
 <AccessControlSection bind:access={opts.access} required={requireAccessControl} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/solidity/StablecoinControls.svelte
+++ b/packages/ui/src/solidity/StablecoinControls.svelte
@@ -267,4 +267,4 @@
 
 <AccessControlSection bind:access={opts.access} required={requireAccessControl} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/stellar/FungibleControls.svelte
+++ b/packages/ui/src/stellar/FungibleControls.svelte
@@ -95,4 +95,4 @@
 
 <TraitImplementationSection bind:explicitImplementations={opts.explicitImplementations} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/stellar/GovernorControls.svelte
+++ b/packages/ui/src/stellar/GovernorControls.svelte
@@ -104,4 +104,4 @@
 
 <TraitImplementationSection bind:explicitImplementations={opts.explicitImplementations} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/stellar/InfoSection.svelte
+++ b/packages/ui/src/stellar/InfoSection.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
-  import type { Info } from '@openzeppelin/wizard-stellar';
+  import type { Info, OptionsErrorMessages } from '@openzeppelin/wizard-stellar';
   import { infoDefaults } from '@openzeppelin/wizard-stellar';
   import HelpTooltip from '../common/HelpTooltip.svelte';
+  import { error } from '../common/error-tooltip';
 
   export let info: Info;
+
+  export let errors: OptionsErrorMessages | undefined = undefined;
 </script>
 
 <section class="controls-section">
@@ -21,11 +24,11 @@
         Where people can contact you to report security issues. Will only be visible if contract metadata is verified.
       </HelpTooltip>
     </span>
-    <input bind:value={info.securityContact} placeholder="security@example.com" />
+    <input bind:value={info.securityContact} placeholder="security@example.com" use:error={errors?.securityContact} />
   </label>
 
   <label class="labeled-input">
     <span>License</span>
-    <input bind:value={info.license} placeholder={infoDefaults.license} />
+    <input bind:value={info.license} placeholder={infoDefaults.license} use:error={errors?.license} />
   </label>
 </section>

--- a/packages/ui/src/stellar/NonFungibleControls.svelte
+++ b/packages/ui/src/stellar/NonFungibleControls.svelte
@@ -153,4 +153,4 @@
 
 <TraitImplementationSection bind:explicitImplementations={opts.explicitImplementations} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/stellar/StablecoinControls.svelte
+++ b/packages/ui/src/stellar/StablecoinControls.svelte
@@ -116,4 +116,4 @@
 
 <TraitImplementationSection bind:explicitImplementations={opts.explicitImplementations} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/stylus/ERC1155Controls.svelte
+++ b/packages/ui/src/stylus/ERC1155Controls.svelte
@@ -61,4 +61,4 @@
 <!-- TODO: uncomment once Stylus constructors are supported -->
 <!-- <AccessControlSection bind:access={opts.access} required={requireAccessControl} /> -->
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/stylus/ERC20Controls.svelte
+++ b/packages/ui/src/stylus/ERC20Controls.svelte
@@ -72,4 +72,4 @@
 <!-- TODO: uncomment once Stylus constructors are supported -->
 <!-- <AccessControlSection bind:access={opts.access} required={requireAccessControl} /> -->
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/stylus/ERC721Controls.svelte
+++ b/packages/ui/src/stylus/ERC721Controls.svelte
@@ -63,4 +63,4 @@
 <!-- TODO: uncomment once Stylus constructors are supported -->
 <!-- <AccessControlSection bind:access={opts.access} required={requireAccessControl} /> -->
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />

--- a/packages/ui/src/stylus/InfoSection.svelte
+++ b/packages/ui/src/stylus/InfoSection.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
-  import type { Info } from '@openzeppelin/wizard-stylus';
+  import type { Info, OptionsErrorMessages } from '@openzeppelin/wizard-stylus';
   import { infoDefaults } from '@openzeppelin/wizard-stylus';
   import HelpTooltip from '../common/HelpTooltip.svelte';
+  import { error } from '../common/error-tooltip';
 
   export let info: Info;
+
+  export let errors: OptionsErrorMessages | undefined = undefined;
 </script>
 
 <section class="controls-section">
@@ -21,11 +24,11 @@
         Where people can contact you to report security issues. Will only be visible if contract metadata is verified.
       </HelpTooltip>
     </span>
-    <input bind:value={info.securityContact} placeholder="security@example.com" />
+    <input bind:value={info.securityContact} placeholder="security@example.com" use:error={errors?.securityContact} />
   </label>
 
   <label class="labeled-input">
     <span>License</span>
-    <input bind:value={info.license} placeholder={infoDefaults.license} />
+    <input bind:value={info.license} placeholder={infoDefaults.license} use:error={errors?.license} />
   </label>
 </section>

--- a/packages/ui/src/uniswap-hooks/HooksControls.svelte
+++ b/packages/ui/src/uniswap-hooks/HooksControls.svelte
@@ -202,7 +202,7 @@
 
 <AccessControlSection bind:access={opts.access} required={requireAccessControl} />
 
-<InfoSection bind:info={opts.info} />
+<InfoSection bind:info={opts.info} {errors} />
 
 <style>
   /* Target the controls-section inside this specific component */


### PR DESCRIPTION
`info.securityContact` and `info.license` are printed into a single-line comment in the generated source (the `// SPDX-License-Identifier:` line and the security-contact comment). If a value contains a line break, it no longer stays on that one comment line.

`setInfo` now throws `OptionsError` when either field contains `\n`, `\r`, `U+2028`, or `U+2029` — the newline characters plus the two Unicode line separators that editors and some compilers also treat as line breaks — keeping these metadata fields to a single line. Applied across the Solidity, Cairo, Stellar, and Stylus generators (and inherited by Confidential and Uniswap Hooks via the Solidity core), with tests and a changeset.

Also surfaces the resulting validation error inline on the Security Contact and License fields in the UI, consistent with how other field errors are shown.