### PR TITLE
fix(stellar): assert on raw token name in generated rust tests

### DIFF
--- a/packages/core/stellar/src/zip-rust.ts
+++ b/packages/core/stellar/src/zip-rust.ts
@@ -40,7 +40,7 @@ export const createRustZipEnvironment = (c: Contract, opts: GenericOptions) => {
   zip.file(`contracts/${contractName}/src/contract.rs`, removeCreateLevelAttributes(printContract(c)));
   zip.file(
     `contracts/${contractName}/src/test.rs`,
-    opts?.kind === 'Vault' ? printVaultRustTest(c) : printRustNameTest(c),
+    opts?.kind === 'Vault' ? printVaultRustTest(c, opts.name) : printRustNameTest(c, opts.name),
   );
   zip.file(`contracts/${contractName}/src/lib.rs`, createRustLibFile);
   zip.file(`contracts/${contractName}/Cargo.toml`, printContractCargo(contractName, requiredLibDeps));

--- a/packages/core/stellar/src/zip-shared.test.ts
+++ b/packages/core/stellar/src/zip-shared.test.ts
@@ -115,7 +115,7 @@ test('printRustNameTest generates test code with address args', t => {
       { name: 'admin', type: 'Address' },
     ],
   };
-  const output = printRustNameTest(contract);
+  const output = printRustNameTest(contract, contract.name);
 
   const expected = `#![cfg(test)]
 
@@ -145,7 +145,7 @@ test('printRustNameTest generates test code without address args', t => {
     name: 'NoArgs',
     constructorArgs: [],
   };
-  const output = printRustNameTest(contract);
+  const output = printRustNameTest(contract, contract.name);
 
   const expected = `#![cfg(test)]
 
@@ -175,7 +175,7 @@ test('printRustNameTest handles single address arg', t => {
     name: 'SingleArg',
     constructorArgs: [{ name: 'owner', type: 'Address' }],
   };
-  const output = printRustNameTest(contract);
+  const output = printRustNameTest(contract, contract.name);
 
   const expected = `#![cfg(test)]
 
@@ -193,6 +193,36 @@ fn initial_state() {
     let client = SingleArgClient::new(&env, &contract_addr);
 
     assert_eq!(client.name(), String::from_str(&env, "SingleArg"));
+}
+
+// Add more tests bellow
+`;
+  t.is(output, expected);
+});
+
+test('printRustNameTest uses raw token name with spaces in assertion', t => {
+  const contract = {
+    name: 'MyToken',
+    constructorArgs: [],
+  };
+  const output = printRustNameTest(contract, 'My Token');
+
+  const expected = `#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{ Env, String };
+
+use crate::contract::{ MyToken, MyTokenClient };
+
+#[test]
+fn initial_state() {
+    let env = Env::default();
+
+    let contract_addr = env.register(MyToken, ());
+    let client = MyTokenClient::new(&env, &contract_addr);
+
+    assert_eq!(client.name(), String::from_str(&env, "My Token"));
 }
 
 // Add more tests bellow

--- a/packages/core/stellar/src/zip-shared.test.ts
+++ b/packages/core/stellar/src/zip-shared.test.ts
@@ -230,6 +230,36 @@ fn initial_state() {
   t.is(output, expected);
 });
 
+test('printRustNameTest escapes quotes and backslashes in token name within assertion', t => {
+  const contract = {
+    name: 'MyToken',
+    constructorArgs: [],
+  };
+  const output = printRustNameTest(contract, 'My "Cool" \\Token');
+
+  const expected = `#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{ Env, String };
+
+use crate::contract::{ MyToken, MyTokenClient };
+
+#[test]
+fn initial_state() {
+    let env = Env::default();
+
+    let contract_addr = env.register(MyToken, ());
+    let client = MyTokenClient::new(&env, &contract_addr);
+
+    assert_eq!(client.name(), String::from_str(&env, "My \\\"Cool\\\" \\\\Token"));
+}
+
+// Add more tests bellow
+`;
+  t.is(output, expected);
+});
+
 test('printContractCargo output includes only required dependencies forwarding to workspace', t => {
   const scaffoldContractName = 'test';
   const output = printContractCargo(scaffoldContractName, ['stellar-tokens', 'stellar-access']);

--- a/packages/core/stellar/src/zip-shared.ts
+++ b/packages/core/stellar/src/zip-shared.ts
@@ -16,7 +16,7 @@ export function getAddressArgs(c: Pick<Contract, 'constructorArgs'>): string[] {
     .map(constructorArg => constructorArg.name);
 }
 
-export const printRustNameTest = (c: Pick<Contract, 'constructorArgs' | 'name'>) => `#![cfg(test)]
+export const printRustNameTest = (c: Pick<Contract, 'constructorArgs' | 'name'>, tokenName: string) => `#![cfg(test)]
 
 extern crate std;
 
@@ -33,7 +33,7 @@ fn initial_state() {
       .join(',')}${getAddressArgs(c).length === 1 ? ',' : ''}));
     let client = ${c.name}Client::new(&env, &contract_addr);
 
-    assert_eq!(client.name(), String::from_str(&env, "${c.name}"));
+    assert_eq!(client.name(), String::from_str(&env, "${tokenName}"));
 }
 
 // Add more tests bellow
@@ -44,7 +44,7 @@ fn initial_state() {
 // no `decimals()` to call, so the test deploys a minimal mock fungible asset
 // first and registers the vault against it. A single-element tuple needs a
 // trailing comma in Rust.
-export const printVaultRustTest = (c: Pick<Contract, 'constructorArgs' | 'name'>) => {
+export const printVaultRustTest = (c: Pick<Contract, 'constructorArgs' | 'name'>, tokenName: string) => {
   const registerArgs = (c.constructorArgs || []).map(arg =>
     arg.name === 'asset' ? 'asset_address.clone()' : 'Address::generate(&env)',
   );
@@ -94,7 +94,7 @@ fn initial_state() {
     let client = ${c.name}Client::new(&env, &contract_addr);
 
     assert_eq!(client.query_asset(), asset_address);
-    assert_eq!(client.name(), String::from_str(&env, "${c.name}"));
+    assert_eq!(client.name(), String::from_str(&env, "${tokenName}"));
 }
 
 // Add more tests bellow

--- a/packages/core/stellar/src/zip-shared.ts
+++ b/packages/core/stellar/src/zip-shared.ts
@@ -16,6 +16,10 @@ export function getAddressArgs(c: Pick<Contract, 'constructorArgs'>): string[] {
     .map(constructorArg => constructorArg.name);
 }
 
+function escapeRustString(str: string): string {
+  return str.replace(/(\\|")/g, '\\$1');
+}
+
 export const printRustNameTest = (c: Pick<Contract, 'constructorArgs' | 'name'>, tokenName: string) => `#![cfg(test)]
 
 extern crate std;
@@ -33,7 +37,7 @@ fn initial_state() {
       .join(',')}${getAddressArgs(c).length === 1 ? ',' : ''}));
     let client = ${c.name}Client::new(&env, &contract_addr);
 
-    assert_eq!(client.name(), String::from_str(&env, "${tokenName}"));
+    assert_eq!(client.name(), String::from_str(&env, "${escapeRustString(tokenName)}"));
 }
 
 // Add more tests bellow
@@ -94,7 +98,7 @@ fn initial_state() {
     let client = ${c.name}Client::new(&env, &contract_addr);
 
     assert_eq!(client.query_asset(), asset_address);
-    assert_eq!(client.name(), String::from_str(&env, "${tokenName}"));
+    assert_eq!(client.name(), String::from_str(&env, "${escapeRustString(tokenName)}"));
 }
 
 // Add more tests bellow


### PR DESCRIPTION
### Description

This PR fixes a bug in the generated Soroban Rust tests where the name assertion fails for token names containing spaces or special characters. 

### Root Cause
- The `ContractBuilder` constructor converts a user-supplied name (e.g. `"My Token"`) to a valid Rust struct identifier (e.g. `"MyToken"`) and stores it as `c.name`.
- When asserting on the token's name, the generated test files (`printRustNameTest` and `printVaultRustTest`) were using `c.name` (the Rust struct identifier). 
- However, at runtime, `client.name()` returns the raw token name supplied to `Base::set_metadata(...)` (e.g. `"My Token"`).
- Consequently, the generated tests would fail whenever the token name contained spaces or non-identifier characters.

### Changes
- Updated `printRustNameTest` and `printVaultRustTest` inside `zip-shared.ts` to accept `tokenName: string` and use it in the assertion rather than `c.name`.
- Threaded `opts.name` (the raw user input) into the test printing functions within `zip-rust.ts`.
- Added a unit test validating that raw token names with spaces generate the correct assertion string while keeping the sanitized identifier for the struct.
