### PR TITLE
Fix Governor Cross-Chain Execution appearing as an empty dropdown

### DIFF
--- a/packages/ui/src/solidity/GovernorControls.svelte
+++ b/packages/ui/src/solidity/GovernorControls.svelte
@@ -157,7 +157,7 @@
       Cross-Chain Execution
       <HelpTooltip link="https://docs.openzeppelin.com/contracts/5.x/api/governance#GovernorCrosschain">
         Lets passed proposals relay execution to other chains through ERC-7786 gateways. Requires a
-        CrosschainRemoteExecutor contract, controlled by this governor, deployed on each target chain.
+        <code>CrosschainRemoteExecutor</code> contract, controlled by this governor, deployed on each target chain.
       </HelpTooltip>
     </label>
   </div>

--- a/packages/ui/src/solidity/GovernorControls.svelte
+++ b/packages/ui/src/solidity/GovernorControls.svelte
@@ -5,7 +5,6 @@
   import { governor, infoDefaults } from '@openzeppelin/wizard';
 
   import ExpandableToggleRadio from '../common/ExpandableToggleRadio.svelte';
-  import ExpandableCheckbox from '../common/ExpandableCheckbox.svelte';
   import UpgradeabilitySection from './UpgradeabilitySection.svelte';
   import InfoSection from './InfoSection.svelte';
 
@@ -152,6 +151,15 @@
         Enable storage of proposal details and enumerability of proposals.
       </HelpTooltip>
     </label>
+
+    <label class:checked={opts.crossChainExecution}>
+      <input type="checkbox" bind:checked={opts.crossChainExecution} />
+      Cross-Chain Execution
+      <HelpTooltip link="https://docs.openzeppelin.com/contracts/5.x/api/governance#GovernorCrosschain">
+        Lets passed proposals relay execution to other chains through ERC-7786 gateways. Requires a
+        CrosschainRemoteExecutor contract, controlled by this governor, deployed on each target chain.
+      </HelpTooltip>
+    </label>
   </div>
 </section>
 
@@ -255,13 +263,6 @@
     </label>
   </div>
 </ExpandableToggleRadio>
-
-<ExpandableCheckbox
-  label="Cross-Chain Execution"
-  bind:checked={opts.crossChainExecution}
-  helpContent="Lets passed proposals relay execution to other chains through ERC-7786 gateways. Requires a CrosschainRemoteExecutor contract, controlled by this governor, deployed on each target chain."
-  helpLink="https://docs.openzeppelin.com/contracts/5.x/api/governance#GovernorCrosschain"
-/>
 
 <UpgradeabilitySection bind:upgradeable={opts.upgradeable} />
 


### PR DESCRIPTION
Cross-Chain Execution is a single boolean with no sub-options, but was rendered as an expandable section whose chevron toggled an empty region.

It's now a plain checkbox in the Settings group next to Storage, matching how other single-boolean Governor extensions appear.