### PR TITLE
Feat/stellar :  added validation policies for Governor voting parameters

### DIFF
--- a/packages/core/stellar/src/governor.test.ts
+++ b/packages/core/stellar/src/governor.test.ts
@@ -81,3 +81,30 @@ testAPIEquivalence('governor API custom', {
 test('governor API assert defaults', async t => {
   t.is(governor.print(governor.defaults), governor.print());
 });
+
+test('governor validation votingDelay < 1', t => {
+  const err = t.throws(() => {
+    buildGovernor({ name: 'MyGovernor', votingDelay: '0' });
+  });
+  t.is(err?.messages?.votingDelay, 'Voting delay must be at least 1 ledger');
+});
+
+test('governor validation votingPeriod <= votingDelay', t => {
+  const err = t.throws(() => {
+    buildGovernor({ name: 'MyGovernor', votingDelay: '100', votingPeriod: '50' });
+  });
+  t.is(err?.messages?.votingPeriod, 'Voting period must be greater than voting delay');
+
+  const errEqual = t.throws(() => {
+    buildGovernor({ name: 'MyGovernor', votingDelay: '100', votingPeriod: '100' });
+  });
+  t.is(errEqual?.messages?.votingPeriod, 'Voting period must be greater than voting delay');
+});
+
+test('governor validation invalid proposalThreshold', t => {
+  const err = t.throws(() => {
+    buildGovernor({ name: 'MyGovernor', proposalThreshold: '-10' });
+  });
+  t.is(err?.messages?.proposalThreshold, 'Not a valid number');
+});
+

--- a/packages/core/stellar/src/governor.ts
+++ b/packages/core/stellar/src/governor.ts
@@ -5,6 +5,8 @@ import { printContract } from './print';
 import { setAccessControl } from './set-access-control';
 import { addUpgradeable } from './add-upgradeable';
 import { setInfo } from './set-info';
+import type { OptionsErrorMessages } from './error';
+import { OptionsError } from './error';
 import { toByteArray, toUint } from './utils/convert-strings';
 import { defineFunctions } from './utils/define-functions';
 
@@ -57,16 +59,72 @@ function withDefaults(opts: GovernorOptions): Required<GovernorOptions> {
 
 export function buildGovernor(opts: GovernorOptions): ContractBuilder {
   const allOpts = withDefaults(opts);
+  const errors: OptionsErrorMessages = {};
+
+  let votingDelay = 0n;
+  try {
+    votingDelay = toUint(allOpts.votingDelay, 'votingDelay', 'u32');
+    if (votingDelay < 1n) {
+      errors.votingDelay = 'Voting delay must be at least 1 ledger';
+    }
+  } catch (e: unknown) {
+    if (e instanceof OptionsError) {
+      Object.assign(errors, e.messages);
+    } else {
+      throw e;
+    }
+  }
+
+  let votingPeriod = 0n;
+  try {
+    votingPeriod = toUint(allOpts.votingPeriod, 'votingPeriod', 'u32');
+    if (votingDelay >= 1n && votingPeriod <= votingDelay) {
+      errors.votingPeriod = 'Voting period must be greater than voting delay';
+    }
+  } catch (e: unknown) {
+    if (e instanceof OptionsError) {
+      Object.assign(errors, e.messages);
+    } else {
+      throw e;
+    }
+  }
+
+  let proposalThreshold = 0n;
+  try {
+    proposalThreshold = toUint(allOpts.proposalThreshold, 'proposalThreshold', 'u128');
+  } catch (e: unknown) {
+    if (e instanceof OptionsError) {
+      Object.assign(errors, e.messages);
+    } else {
+      throw e;
+    }
+  }
+
+  let quorum = 0n;
+  try {
+    quorum = toUint(allOpts.quorum, 'quorum', 'u128');
+  } catch (e: unknown) {
+    if (e instanceof OptionsError) {
+      Object.assign(errors, e.messages);
+    } else {
+      throw e;
+    }
+  }
+
+  if (Object.keys(errors).length > 0) {
+    throw new OptionsError(errors);
+  }
+
   const c = new ContractBuilder(allOpts.name);
 
   addBase(
     c,
     toByteArray(allOpts.name),
     toByteArray(allOpts.version),
-    toUint(allOpts.votingDelay, 'votingDelay', 'u32'),
-    toUint(allOpts.votingPeriod, 'votingPeriod', 'u32'),
-    toUint(allOpts.proposalThreshold, 'proposalThreshold', 'u128'),
-    toUint(allOpts.quorum, 'quorum', 'u128'),
+    votingDelay,
+    votingPeriod,
+    proposalThreshold,
+    quorum,
     allOpts.timelock,
     allOpts.explicitImplementations,
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,6 +677,13 @@
     semver "^7.5.3"
     tar "^7.4.0"
 
+"@modelcontextprotocol/ext-apps@1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.5.tgz#53004fadf7bef79c533e28b10893199c7bf46693"
+  integrity sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+
 "@modelcontextprotocol/sdk@^1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz#79786d8b525e269de850ac82b1f1f757f3915f44"
@@ -893,8 +900,9 @@
   integrity sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==
 
 "@openzeppelin/contracts@^5.5.0":
-  version "5.5.0"
-  resolved "git+https://github.com/OpenZeppelin/openzeppelin-contracts.git#bacb570d143e637c6637a68727795f4e71aac891"
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.6.1.tgz#90c1cd427b3c1007ada4f42378ce84cc2a2145a5"
+  integrity sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==
 
 "@openzeppelin/contracts@^5.6.0":
   version "5.6.0"
@@ -1208,6 +1216,11 @@
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz#719df7fb41766bc143369eaa0dd56d8dc87c9958"
   integrity sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==
+
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
 "@trysound/sax@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
## 📌 Overview
This pull request introduces strict, field-level configuration validation for key governance parameters (Voting Delay, Voting Period, and Proposal Threshold) within @openzeppelin/wizard-stellar.

##  What Was The Issue?
Prior to this change, the Stellar Contracts Wizard UI allowed users to enter invalid governance configurations—such as setting a votingDelay of 0 or setting a votingPeriod smaller than or equal to votingDelay—without displaying inline validation errors.

Generating a Soroban smart contract with invalid governance configurations presents severe issues:

1) Security & Protocol Risks: A Governor deployed with zero voting delay allows instant voting execution without giving token holders or delegates notice to review proposals.
2) Governance Deadlocks: Setting a votingPeriod less than or equal to votingDelay creates an unexecutable contract where voting closes before or at the same time it opens.
3) Suboptimal Developer Experience: Developers were only alerted to invalid governance parameters during downstream compilation or mainnet/testnet deployment.

## What Is The Solution?
We implemented comprehensive, field-scoped validation logic inside buildGovernor within @openzeppelin/wizard-stellar, backed by unit tests:

- Voting Delay: Enforced a minimum requirement of $\ge 1$ ledger (votingDelay >= 1n). If $< 1$, attaches the error message 'Voting delay must be at least 1 ledger' to errors.votingDelay.
- Voting Period: Enforced that Voting Period must be strictly greater than Voting Delay ($votingPeriod > votingDelay$). If $votingPeriod \le votingDelay$, attaches the error message 'Voting period must be greater than voting delay' to errors.votingPeriod.
- Proposal Threshold: Enforced non-negative u128 integer parsing.
- Unified Error Feedback: Accumulated field validation errors into an OptionsError instance, populating inline error tooltips (use:error) in GovernorControls.svelte and automatically disabling export/download buttons until configuration errors are resolved.

## 🛠️ How We Solved It
1. Core Generator Engine (packages/core/stellar/src/governor.ts)
Updated buildGovernor(opts) to validate values and collect field-mapped error messages:

const errors: OptionsErrorMessages = {};

let votingDelay = 0n;
try {
  votingDelay = toUint(allOpts.votingDelay, 'votingDelay', 'u32');
  if (votingDelay < 1n) {
    errors.votingDelay = 'Voting delay must be at least 1 ledger';
  }
} catch (e: unknown) {
  if (e instanceof OptionsError) Object.assign(errors, e.messages);
  else throw e;
}

let votingPeriod = 0n;
try {
  votingPeriod = toUint(allOpts.votingPeriod, 'votingPeriod', 'u32');
  if (votingDelay >= 1n && votingPeriod <= votingDelay) {
    errors.votingPeriod = 'Voting period must be greater than voting delay';
  }
} catch (e: unknown) {
  if (e instanceof OptionsError) Object.assign(errors, e.messages);
  else throw e;
}

if (Object.keys(errors).length > 0) {
  throw new OptionsError(errors);
}

2. Unit Testing Suite (packages/core/stellar/src/governor.test.ts)
Added AVA unit tests verifying that invalid configurations throw appropriate error payloads:

- governor validation votingDelay < 1
- governor validation votingPeriod <= votingDelay
- governor validation invalid proposalThreshold
>All 13 unit tests pass cleanly:

## Why Is This So Important?
- Prevents On-Chain Security Flaws: Governance smart contracts control protocol upgrades and DAOs. Catching invalid parameters at the wizard generator level prevents broken contracts from being deployed on the Stellar network.
- Enhances Developer Productivity: Instant visual feedback via red error tooltips guides developers to construct valid governance parameters without reading raw error logs.
- Upholds OpenZeppelin Quality Standards: Ensures the Stellar Soroban Wizard adheres to the same rigorous validation standards established across OpenZeppelin's Solidity and Cairo wizards
<img width="1904" height="909" alt="image" src="https://github.com/user-attachments/assets/24f88bc4-39ce-47c2-8c6a-3dc5a415c02c" />
