### PR TITLE
Strip changelog heading dates during publish for GitHub release notes

### DIFF
--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -15,3 +15,7 @@ fi
 yarn install --frozen-lockfile
 changeset publish
 git push --follow-tags
+
+# Strip dates from changelog version headings (working tree only) so that the
+# changesets action can extract each version's section for GitHub release notes.
+node scripts/release/strip-changelog-dates.mjs || echo "Failed to strip changelog dates. GitHub release notes may contain the full changelog."

--- a/scripts/release/strip-changelog-dates.mjs
+++ b/scripts/release/strip-changelog-dates.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+// Removes the date suffix from version headings in all packages' changelogs,
+// e.g. `## 1.2.3 (2026-08-17)` -> `## 1.2.3`, modifying the working tree only.
+//
+// The changesets GitHub Action creates GitHub releases by extracting the
+// section of CHANGELOG.md whose level-2 heading exactly equals the published
+// version. Our custom format appends a date to the heading, which breaks that
+// match and causes the entire changelog to be used as the release notes.
+// The action reads the changelogs from the working tree after the publish
+// script completes, so stripping the dates here (uncommitted) lets it extract
+// only the current version's section, while the committed changelogs and the
+// published npm packages keep the dated format.
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+const DATED_VERSION_TITLE_REGEX = /^## (\d+\.\d+\.\d+(?:-rc\.\d+)?) \(\d{4}-\d{2}-\d{2}\)$/gm;
+
+function stripChangelogDates(dir) {
+  const changelogPath = join(dir, 'CHANGELOG.md');
+  if (!existsSync(changelogPath)) {
+    return;
+  }
+
+  console.log(`Stripping dates from changelog for ${dir}...`);
+
+  const changelog = readFileSync(changelogPath, 'utf8');
+  writeFileSync(changelogPath, changelog.replace(DATED_VERSION_TITLE_REGEX, '## $1'));
+}
+
+for (const parent of ['./packages', './packages/core']) {
+  for (const entry of readdirSync(parent, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      stripChangelogDates(join(parent, entry.name));
+    }
+  }
+}


### PR DESCRIPTION
The changesets action extracts GitHub release notes by finding the changelog heading that exactly equals the published version. Our custom format appends a date to the heading (`## 1.2.3 (2026-08-17)`), so the match fails and each release gets the entire changelog as its notes.

Since the action reads changelogs from the working tree after the publish script completes, this strips the date suffixes (uncommitted) at the end of `publish.sh` so only the current version's section is extracted. Committed changelogs and npm tarballs keep the dated format.