### PR TITLE
Add supported languages and TRON examples to CLI and MCP READMEs

### DIFF
--- a/.changeset/cli-readme-language-examples.md
+++ b/.changeset/cli-readme-language-examples.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/contracts-cli': patch
+---
+
+Add a supported-languages table and an example command for each language to the README.

--- a/.changeset/cli-readme-language-examples.md
+++ b/.changeset/cli-readme-language-examples.md
@@ -2,4 +2,4 @@
 '@openzeppelin/contracts-cli': patch
 ---
 
-Add a supported-languages table and an example command for each language to the README.
+Add a supported-languages table and an example command for each language to the README. No functional changes.

--- a/.changeset/mcp-readme-tron-row.md
+++ b/.changeset/mcp-readme-tron-row.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/contracts-mcp': patch
+---
+
+Add TRON to the README's language table.

--- a/.changeset/mcp-readme-tron-row.md
+++ b/.changeset/mcp-readme-tron-row.md
@@ -2,4 +2,4 @@
 '@openzeppelin/contracts-mcp': patch
 ---
 
-Add TRON to the README's language table.
+Add TRON to the README's language table. No functional changes.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,23 @@ npx @openzeppelin/contracts-cli --help
 npx @openzeppelin/contracts-cli solidity-erc20 --help
 ```
 
-### Examples
+## Supported languages
+
+Commands are named in the format `<language>-<contract>`.
+
+| Language | Contracts |
+| --- | --- |
+| solidity | erc20, erc721, erc1155, stablecoin, rwa, account, governor, custom |
+| cairo | erc20, erc721, erc1155, account, multisig, governor, vesting, custom |
+| stellar | fungible, stablecoin, non-fungible, governor, vault, account |
+| stylus | erc20, erc721, erc1155 |
+| confidential | erc7984 |
+| uniswap-hooks | hooks (command is just `uniswap-hooks`) |
+| tron | trc20, trc721, trc1155, governor, custom |
+
+## Examples
+
+One example per language. These examples are not exhaustive — run `npx @openzeppelin/contracts-cli --help` for all commands, and `npx @openzeppelin/contracts-cli <command> --help` for all options of a command.
 
 ```sh
 npx @openzeppelin/contracts-cli solidity-erc20 --name MyToken --symbol MTK --mintable --burnable --access ownable
@@ -25,4 +41,35 @@ npx @openzeppelin/contracts-cli solidity-erc20 --name MyToken --symbol MTK --min
 
 ```sh
 npx @openzeppelin/contracts-cli cairo-erc20 --name MyToken --symbol MTK --mintable --pausable --upgradeable
+```
+
+```sh
+npx @openzeppelin/contracts-cli stellar-fungible --name MyToken --symbol MTK --premint 1000 --mintable
+```
+
+```sh
+npx @openzeppelin/contracts-cli stylus-erc721 --name MyNFT --burnable --enumerable
+```
+
+```sh
+npx @openzeppelin/contracts-cli confidential-erc7984 --name MyToken --symbol MTK --contractURI https://example.com/token.json --networkConfig zama-ethereum --wrappable
+```
+
+Uniswap hook callbacks and utilities are configured explicitly:
+
+```sh
+npx @openzeppelin/contracts-cli uniswap-hooks --hook BaseHook --name MyHook \
+  --pausable false --currencySettler false --safeCast false --transientStorage false \
+  --shares.options false --inputs.blockNumberOffset 0 --inputs.maxAbsTickDelta 0 \
+  --permissions.beforeInitialize false --permissions.afterInitialize false \
+  --permissions.beforeAddLiquidity false --permissions.afterAddLiquidity false \
+  --permissions.beforeRemoveLiquidity false --permissions.afterRemoveLiquidity false \
+  --permissions.beforeSwap --permissions.afterSwap \
+  --permissions.beforeDonate false --permissions.afterDonate false \
+  --permissions.beforeSwapReturnDelta false --permissions.afterSwapReturnDelta false \
+  --permissions.afterAddLiquidityReturnDelta false --permissions.afterRemoveLiquidityReturnDelta false
+```
+
+```sh
+npx @openzeppelin/contracts-cli tron-trc20 --name MyToken --symbol MTK --mintable --upgradeable uups
 ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,15 +25,15 @@ Commands are named in the format `<language>-<contract>`.
 | --- | --- |
 | solidity | erc20, erc721, erc1155, stablecoin, rwa, account, governor, custom |
 | cairo | erc20, erc721, erc1155, account, multisig, governor, vesting, custom |
+| confidential | erc7984 |
 | stellar | fungible, stablecoin, non-fungible, governor, vault, account |
 | stylus | erc20, erc721, erc1155 |
-| confidential | erc7984 |
-| uniswap-hooks | hooks (command is just `uniswap-hooks`) |
 | tron | trc20, trc721, trc1155, governor, custom |
+| uniswap-hooks | hooks (command is just `uniswap-hooks`) |
 
 ## Examples
 
-One example per language. These examples are not exhaustive — run `npx @openzeppelin/contracts-cli --help` for all commands, and `npx @openzeppelin/contracts-cli <command> --help` for all options of a command.
+These examples are not exhaustive — run `npx @openzeppelin/contracts-cli --help` for all commands, and `npx @openzeppelin/contracts-cli <command> --help` for all options of a command.
 
 ```sh
 npx @openzeppelin/contracts-cli solidity-erc20 --name MyToken --symbol MTK --mintable --burnable --access ownable
@@ -41,6 +41,10 @@ npx @openzeppelin/contracts-cli solidity-erc20 --name MyToken --symbol MTK --min
 
 ```sh
 npx @openzeppelin/contracts-cli cairo-erc20 --name MyToken --symbol MTK --mintable --pausable --upgradeable
+```
+
+```sh
+npx @openzeppelin/contracts-cli confidential-erc7984 --name MyToken --symbol MTK --contractURI https://example.com/token.json --networkConfig zama-ethereum --wrappable
 ```
 
 ```sh
@@ -52,10 +56,8 @@ npx @openzeppelin/contracts-cli stylus-erc721 --name MyNFT --burnable --enumerab
 ```
 
 ```sh
-npx @openzeppelin/contracts-cli confidential-erc7984 --name MyToken --symbol MTK --contractURI https://example.com/token.json --networkConfig zama-ethereum --wrappable
+npx @openzeppelin/contracts-cli tron-trc20 --name MyToken --symbol MTK --mintable --upgradeable uups
 ```
-
-Uniswap hook callbacks and utilities are configured explicitly:
 
 ```sh
 npx @openzeppelin/contracts-cli uniswap-hooks --hook BaseHook --name MyHook \
@@ -68,8 +70,4 @@ npx @openzeppelin/contracts-cli uniswap-hooks --hook BaseHook --name MyHook \
   --permissions.beforeDonate false --permissions.afterDonate false \
   --permissions.beforeSwapReturnDelta false --permissions.afterSwapReturnDelta false \
   --permissions.afterAddLiquidityReturnDelta false --permissions.afterRemoveLiquidityReturnDelta false
-```
-
-```sh
-npx @openzeppelin/contracts-cli tron-trc20 --name MyToken --symbol MTK --mintable --upgradeable uups
 ```

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -72,6 +72,43 @@ test('each core kind has cli registry entry', async t => {
   }
 });
 
+// --- README completeness ---
+// The README is what npm renders for the package, so a language shipped without
+// a table row or example there is invisible to anyone browsing the npm page.
+
+/** `uniswap-hooks` is a whole command; every other command is `<language>-<contract>`. */
+function commandLanguage(command: string): string {
+  return command === 'uniswap-hooks' ? command : command.split('-')[0]!;
+}
+
+test('each registry command is listed in the README table', async t => {
+  const readme = await readFile(join(__dirname, '..', 'README.md'), 'utf-8');
+
+  for (const command of Object.keys(registry)) {
+    const language = commandLanguage(command);
+    const row = readme.split('\n').find(line => line.startsWith(`| ${language} |`));
+
+    t.truthy(row, `packages/cli/README.md 'Supported languages' table is missing a row for '${language}'`);
+    const contract = command.slice(language.length + 1);
+    if (row !== undefined && contract !== '') {
+      t.true(row.includes(contract), `README table row for '${language}' is missing '${contract}'`);
+    }
+  }
+});
+
+test('each registry language has a README example', async t => {
+  const readme = await readFile(join(__dirname, '..', 'README.md'), 'utf-8');
+  const languages = new Set(Object.keys(registry).map(commandLanguage));
+
+  for (const language of languages) {
+    t.regex(
+      readme,
+      new RegExp(`contracts-cli ${language}[ -]`),
+      `packages/cli/README.md 'Examples' is missing an example command for '${language}'`,
+    );
+  }
+});
+
 // --- Help snapshots ---
 
 test('no args', t => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -114,6 +114,24 @@ test('each registry language has a README example', async t => {
   }
 });
 
+test('each README example runs', async t => {
+  const readme = await readFile(join(__dirname, '..', 'README.md'), 'utf-8');
+  const examplesStart = readme.indexOf('## Examples');
+  t.true(examplesStart >= 0, `packages/cli/README.md is missing the '## Examples' section`);
+  const blocks = [...readme.slice(examplesStart).matchAll(/```sh\n(.*?)```/gs)].map(match => match[1]!);
+  t.true(blocks.length > 0, 'Expected sh blocks in the Examples section');
+
+  for (const block of blocks) {
+    // Join backslash line continuations the way a shell would.
+    const command = block.replace(/\\\n/g, ' ').trim();
+    t.true(command.startsWith('npx @openzeppelin/contracts-cli '), `Unexpected example command: ${command}`);
+
+    const args = command.replace('npx @openzeppelin/contracts-cli ', '').split(/\s+/);
+    const output = run(...args);
+    t.true(output.length > 0, `Example printed no contract: ${command}`);
+  }
+});
+
 // --- Help snapshots ---
 
 test('no args', t => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -98,11 +98,16 @@ test('each registry command is listed in the README table', async t => {
 
 test('each registry language has a README example', async t => {
   const readme = await readFile(join(__dirname, '..', 'README.md'), 'utf-8');
+  // Match only within the Examples section, so commands mentioned elsewhere
+  // (e.g. the `--help` invocation under Usage) cannot satisfy the check.
+  const examplesStart = readme.indexOf('## Examples');
+  t.true(examplesStart >= 0, `packages/cli/README.md is missing the '## Examples' section`);
+  const examples = readme.slice(examplesStart);
   const languages = new Set(Object.keys(registry).map(commandLanguage));
 
   for (const language of languages) {
     t.regex(
-      readme,
+      examples,
       new RegExp(`contracts-cli ${language}[ -]`),
       `packages/cli/README.md 'Examples' is missing an example command for '${language}'`,
     );

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -20,6 +20,7 @@ Provides tools to generate smart contract source code for the following language
 | confidential | erc7984 |
 | stellar | fungible, stablecoin, non-fungible, governor, vault, account |
 | stylus | erc20, erc721, erc1155 |
+| tron | trc20, trc721, trc1155, governor, custom |
 | uniswap-hooks | hooks (tool name is just `uniswap-hooks`) |
 
 ### MCP Apps

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -130,6 +130,32 @@ test('each mcp tools folder is exported from index.ts', async t => {
 });
 
 /**
+ * The README is what npm renders for the package, so a language shipped without
+ * a row in its table is invisible to anyone browsing the npm page (TRON was
+ * initially missed this way).
+ */
+test('each mcp language has a README table row listing its tools', async t => {
+  const readme = await readFile(join(__dirname, '..', 'README.md'), 'utf-8');
+  const byLanguage = new Map<string, string[]>();
+
+  for (const { language, toolName } of await listExpectedWizardTools()) {
+    const suffix = toolName.startsWith(`${language}-`) ? toolName.slice(language.length + 1) : toolName;
+    byLanguage.set(language, [...(byLanguage.get(language) ?? []), suffix]);
+  }
+
+  for (const [language, suffixes] of byLanguage) {
+    const row = readme.split('\n').find(line => line.startsWith(`| ${language} |`));
+
+    t.truthy(row, `packages/mcp/README.md language table is missing a row for '${language}'`);
+    if (row === undefined) continue;
+
+    for (const suffix of suffixes) {
+      t.true(row.includes(suffix), `README table row for '${language}' is missing '${suffix}'`);
+    }
+  }
+});
+
+/**
  * Kind-level counterpart to the language check above, mirroring `each core kind has cli registry
  * entry` in packages/cli: a kind added to an existing core language must also get an MCP tool.
  * Languages are the core∩mcp intersection; a core language with no MCP folder at all is the first


### PR DESCRIPTION
## Summary
- CLI README: adds a supported-languages table (7 languages with their contract kinds) and one runnable example per language, including TRON, plus a pointer to `--help` for the full set. Requested by TRON, matching the existing solidity/cairo examples.
- MCP README: adds the missing `tron` row to the language table (the tools shipped in #806; the table was not updated).
- New tests keep the READMEs complete: cli asserts every registry command appears in the table, every language has an example, and every example command executes successfully against the CLI; mcp asserts every registered tool is listed in its language's row. These files are the npm pages, so a missing row or a broken example is invisible to us and visible to npm users.
- Patch changesets for `@openzeppelin/contracts-cli` and `@openzeppelin/contracts-mcp` so the npm pages refresh on the next publish.
- The `uniswap-hooks` example is long because the command currently has no defaults — every permission and input must be passed explicitly. The example reflects reality; making those optional is a separate CLI change.

## Test plan
- [x] Every README example command was run against the built CLI and prints a contract — now also enforced by the `each README example runs` test.
- [x] `packages/cli` ava (92 passed) and `packages/mcp` ava (97 passed), including the new README-completeness tests.
- [x] Drift protection verified: deleting the tron table row locally fails `each registry command is listed in the README table` with a message naming the missing language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)