### PR TITLE
ci: declare explicit GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -14,6 +14,9 @@ concurrency:
   group: changeset-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/compile-cairo-alpha-project.yml
+++ b/.github/workflows/compile-cairo-alpha-project.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'packages/core/cairo_alpha/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate-cairo-alpha:
     runs-on: ubuntu-latest

--- a/.github/workflows/compile-cairo-project.yml
+++ b/.github/workflows/compile-cairo-project.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'packages/core/cairo/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate-cairo:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   static-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The product-security baseline rollout will set the repository default `GITHUB_TOKEN` permissions to **read-only** (with PR-approval by the token disabled). Workflows that rely on the current implicit write default would start failing at their next write operation. This PR makes each workflow's required permissions explicit so the downgrade is a no-op for this repo.

| Workflow | Declared permissions |
|---|---|
| `.github/workflows/changeset.yml` | `contents: read` |
| `.github/workflows/compile-cairo-alpha-project.yml` | `contents: read` |
| `.github/workflows/compile-cairo-project.yml` | `contents: read` |
| `.github/workflows/test.yml` | `contents: read` |

Scopes were inferred from the actions and commands each workflow uses; read-only workflows get `contents: read`. Draft on purpose — please review before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)