### PR TITLE
Improve layout on small screens

### DIFF
--- a/packages/ui/public/index.html
+++ b/packages/ui/public/index.html
@@ -105,13 +105,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="switch switch-uniswap-hooks" href="/uniswap-hooks"><img src="/icons/uniswap-hooks.svg" alt="uniswap-hooks">Uniswap Hooks</a>
     </div>
 
-    <div class="flex flex-row gap-2">
-      <div class="text-sm text-gray-600 leading-tight text-right">
+    <div class="ui-builder-cta flex flex-row gap-2">
+      <div class="ui-builder-copy text-sm text-gray-600 leading-tight text-right">
         <div>After deploying a contract, use the</div>
         <div>new UI Builder to spin up a quick UI</div>
       </div>
 
-      <div class="flex items-center">
+      <div class="ui-builder-arrow flex items-center">
         <img src="/icons/arrow-right.svg" alt="arrow-right" class="arrow-gray">
       </div>
 

--- a/packages/ui/public/stellar.html
+++ b/packages/ui/public/stellar.html
@@ -73,13 +73,13 @@
       <a class="switch switch-uniswap-hooks" href="/uniswap-hooks"><img src="/icons/uniswap-hooks.svg" alt="uniswap-hooks">Uniswap Hooks</a>
     </div>
 
-    <div class="flex flex-row gap-2">
-      <div class="text-sm text-gray-600 leading-tight text-right">
+    <div class="ui-builder-cta flex flex-row gap-2">
+      <div class="ui-builder-copy text-sm text-gray-600 leading-tight text-right">
         <div>After deploying a contract, use the</div>
         <div>new UI Builder to spin up a quick UI</div>
       </div>
 
-      <div class="flex items-center">
+      <div class="ui-builder-arrow flex items-center">
         <img src="/icons/arrow-right.svg" alt="arrow-right" class="arrow-gray">
       </div>
 

--- a/packages/ui/public/uniswap-hooks.html
+++ b/packages/ui/public/uniswap-hooks.html
@@ -104,13 +104,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     </div>
 
 
-    <div class="flex flex-row gap-2">
-      <div class="text-sm text-gray-600 leading-tight text-right">
+    <div class="ui-builder-cta flex flex-row gap-2">
+      <div class="ui-builder-copy text-sm text-gray-600 leading-tight text-right">
         <div>After deploying a contract, use the</div>
         <div>new UI Builder to spin up a quick UI</div>
       </div>
   
-      <div class="flex items-center">
+      <div class="ui-builder-arrow flex items-center">
         <img src="/icons/arrow-right.svg" alt="arrow-right" class="arrow-gray">
       </div>
   

--- a/packages/ui/src/cairo/App.svelte
+++ b/packages/ui/src/cairo/App.svelte
@@ -36,6 +36,7 @@
   import type { InitialOptions } from '../common/initial-options';
   import { createWiz, mergeAiAssistanceOptions } from '../common/Wiz.svelte';
   import type { AiFunctionCall } from '../../api/ai-assistant/types/assistant';
+  import { scrollFade } from '../common/scroll-fade';
 
   const dispatch = createEventDispatcher();
 
@@ -189,9 +190,9 @@
     {/if}
   </div>
 
-  <div class="flex flex-row grow">
+  <div class="wizard-panes flex flex-row grow" use:scrollFade={tab}>
     <div
-      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between h-[calc(100vh-84px)] overflow-auto resize-x"
+      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between overflow-auto resize-x"
     >
       <div class:hidden={tab !== 'ERC20'}>
         <ERC20Controls bind:opts={allOpts.ERC20} errors={errors.ERC20} />
@@ -221,7 +222,7 @@
         <CustomControls bind:opts={allOpts.Custom} errors={errors.Custom} />
       </div>
     </div>
-    <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)]">
+    <div class="output rounded-r-3xl flex flex-col grow overflow-auto">
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
           <code class="hljs -cairo grow overflow-auto p-4">{@html highlightedCode}</code>

--- a/packages/ui/src/cairo_alpha/App.svelte
+++ b/packages/ui/src/cairo_alpha/App.svelte
@@ -36,6 +36,7 @@
   import type { InitialOptions } from '../common/initial-options';
   import { createWiz, mergeAiAssistanceOptions } from '../common/Wiz.svelte';
   import type { AiFunctionCall } from '../../api/ai-assistant/types/assistant';
+  import { scrollFade } from '../common/scroll-fade';
 
   const dispatch = createEventDispatcher();
 
@@ -189,9 +190,9 @@
     {/if}
   </div>
 
-  <div class="flex flex-row grow">
+  <div class="wizard-panes flex flex-row grow" use:scrollFade={tab}>
     <div
-      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between h-[calc(100vh-84px)] overflow-auto resize-x"
+      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between overflow-auto resize-x"
     >
       <div class:hidden={tab !== 'ERC20'}>
         <ERC20Controls bind:opts={allOpts.ERC20} errors={errors.ERC20} />
@@ -221,7 +222,7 @@
         <CustomControls bind:opts={allOpts.Custom} errors={errors.Custom} />
       </div>
     </div>
-    <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)]">
+    <div class="output rounded-r-3xl flex flex-col grow overflow-auto">
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
           <code class="hljs -cairo grow overflow-auto p-4">{@html highlightedCode}</code>

--- a/packages/ui/src/common/UnsupportedVersion.svelte
+++ b/packages/ui/src/common/UnsupportedVersion.svelte
@@ -23,7 +23,7 @@
     background-color: var(--gray-1);
     border: 1px solid var(--gray-2);
     border-radius: 10px;
-    min-width: 32rem;
+    min-width: 0;
   }
 
   .header {

--- a/packages/ui/src/common/VersionedApp.svelte
+++ b/packages/ui/src/common/VersionedApp.svelte
@@ -25,8 +25,6 @@
   }
 </script>
 
-<div class="container overflow-hidden">
-  <div class="page-container flex flex-col justify-between overflow-hidden">
-    <svelte:component this={page} {initialTab} {initialOpts} bind:tab={contractTab} />
-  </div>
+<div class="page-container flex flex-col justify-between">
+  <svelte:component this={page} {initialTab} {initialOpts} bind:tab={contractTab} />
 </div>

--- a/packages/ui/src/common/scroll-fade.ts
+++ b/packages/ui/src/common/scroll-fade.ts
@@ -15,15 +15,18 @@ export function scrollFade(node: HTMLElement, _dep?: unknown) {
   };
 
   controls.addEventListener('scroll', update, { passive: true });
-  const observer = new ResizeObserver(update);
-  observer.observe(controls);
+  const resizeObserver = new ResizeObserver(update);
+  resizeObserver.observe(controls);
+  const mutationObserver = new MutationObserver(update);
+  mutationObserver.observe(controls, { childList: true, subtree: true });
   update();
 
   return {
     update,
     destroy() {
       controls.removeEventListener('scroll', update);
-      observer.disconnect();
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
     },
   };
 }

--- a/packages/ui/src/common/scroll-fade.ts
+++ b/packages/ui/src/common/scroll-fade.ts
@@ -12,6 +12,7 @@ export function scrollFade(node: HTMLElement, _dep?: unknown) {
   const update = () => {
     const remaining = controls.scrollHeight - controls.scrollTop - controls.clientHeight;
     node.classList.toggle('controls-at-end', remaining <= 2);
+    node.style.setProperty('--controls-fade-width', `${controls.offsetWidth}px`);
   };
 
   controls.addEventListener('scroll', update, { passive: true });

--- a/packages/ui/src/common/scroll-fade.ts
+++ b/packages/ui/src/common/scroll-fade.ts
@@ -3,7 +3,7 @@
  * child is scrolled to the bottom (or cannot scroll). Used to hide the
  * bottom fade overlay so the last options are fully visible.
  */
-export function scrollFade(node: HTMLElement) {
+export function scrollFade(node: HTMLElement, _dep?: unknown) {
   const controls = node.querySelector<HTMLElement>('.controls');
   if (!controls) {
     return;

--- a/packages/ui/src/common/scroll-fade.ts
+++ b/packages/ui/src/common/scroll-fade.ts
@@ -1,0 +1,29 @@
+/**
+ * Toggles `controls-at-end` on a wizard-panes node when its `.controls`
+ * child is scrolled to the bottom (or cannot scroll). Used to hide the
+ * bottom fade overlay so the last options are fully visible.
+ */
+export function scrollFade(node: HTMLElement) {
+  const controls = node.querySelector<HTMLElement>('.controls');
+  if (!controls) {
+    return;
+  }
+
+  const update = () => {
+    const remaining = controls.scrollHeight - controls.scrollTop - controls.clientHeight;
+    node.classList.toggle('controls-at-end', remaining <= 2);
+  };
+
+  controls.addEventListener('scroll', update, { passive: true });
+  const observer = new ResizeObserver(update);
+  observer.observe(controls);
+  update();
+
+  return {
+    update,
+    destroy() {
+      controls.removeEventListener('scroll', update);
+      observer.disconnect();
+    },
+  };
+}

--- a/packages/ui/src/common/styles/shared.css
+++ b/packages/ui/src/common/styles/shared.css
@@ -61,25 +61,21 @@
     overflow: visible;
   }
 
-  .header {
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  .header .tab {
-    flex: 1 1 100%;
-  }
-
-  .header .action {
-    margin-left: auto;
-  }
-
+  /* Flatten wrappers so the stack is tabs → options → actions → code. */
+  .header,
   .wizard-panes {
-    flex-direction: column;
+    display: contents;
   }
 
   .wizard-panes::after {
     display: none;
+  }
+
+  .tab {
+    order: 0;
+    flex: 0 0 auto;
+    width: 100%;
+    min-width: 0;
   }
 
   .wizard-panes .controls,
@@ -89,17 +85,48 @@
     max-width: 100%;
     height: auto;
     resize: none;
-    border-radius: 1.5rem;
   }
 
   .wizard-panes .controls {
-    max-height: none;
+    order: 1;
+    /* rem, not vh: the embed iframe is sized to content, so vh would recurse. */
+    max-height: 22rem;
+    border-radius: 1.5rem;
     box-shadow: none;
+    -webkit-mask-image: linear-gradient(to bottom, #000 78%, transparent);
+    mask-image: linear-gradient(to bottom, #000 78%, transparent);
+  }
+
+  .wizard-panes.controls-at-end .controls {
+    -webkit-mask-image: none;
+    mask-image: none;
+  }
+
+  .action {
+    order: 2;
+    z-index: 5;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+    width: 100%;
+    box-sizing: border-box;
+    margin-left: 0;
+    /* Collapse the container gap so this toolbar sits on the code card. */
+    margin-bottom: -1rem;
+    padding: 0.4rem 0.6rem;
+    background-color: white;
+    border-radius: 1.5rem 1.5rem 0 0;
+  }
+
+  .action .action-button {
+    padding: 6px 10px;
+    font-size: 13px;
   }
 
   .wizard-panes .output {
-    min-height: 24rem;
-    margin-top: 0.75rem;
+    order: 3;
+    min-height: 32rem;
+    margin-top: 0;
+    border-radius: 0 0 1.5rem 1.5rem;
   }
 }
 

--- a/packages/ui/src/common/styles/shared.css
+++ b/packages/ui/src/common/styles/shared.css
@@ -26,7 +26,7 @@
   position: absolute;
   left: 0;
   bottom: 0;
-  width: 18rem;
+  width: var(--controls-fade-width, 18rem);
   max-width: 100%;
   height: 4.5rem;
   pointer-events: none;

--- a/packages/ui/src/common/styles/shared.css
+++ b/packages/ui/src/common/styles/shared.css
@@ -1,6 +1,106 @@
 .container {
   background-color: var(--gray-1);
-  min-width: 32rem;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.wizard-panes {
+  position: relative;
+  min-width: 0;
+}
+
+.wizard-panes .controls,
+.wizard-panes .output {
+  height: calc(100vh - 84px);
+  min-width: 0;
+}
+
+.header .tab {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.wizard-panes::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 18rem;
+  max-width: 100%;
+  height: 4.5rem;
+  pointer-events: none;
+  background: linear-gradient(to top, rgb(255, 255, 255) 25%, rgba(255, 255, 255, 0.85) 55%, transparent);
+  border-bottom-left-radius: 1.5rem;
+  z-index: 1;
+  opacity: 1;
+  transition: opacity 0.15s ease;
+}
+
+.wizard-panes.controls-at-end::after {
+  opacity: 0;
+}
+
+.wizard-panes .controls {
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray-3) transparent;
+}
+
+.wizard-panes .controls::-webkit-scrollbar {
+  width: 8px;
+}
+
+.wizard-panes .controls::-webkit-scrollbar-thumb {
+  background: var(--gray-3);
+  border-radius: 8px;
+}
+
+@media (max-width: 720px) {
+  .container,
+  .page-container {
+    overflow: visible;
+  }
+
+  .header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .header .tab {
+    flex: 1 1 100%;
+  }
+
+  .header .action {
+    margin-left: auto;
+  }
+
+  .wizard-panes {
+    flex-direction: column;
+  }
+
+  .wizard-panes::after {
+    display: none;
+  }
+
+  .wizard-panes .controls,
+  .wizard-panes .output {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    height: auto;
+    resize: none;
+    border-radius: 1.5rem;
+  }
+
+  .wizard-panes .controls {
+    max-height: none;
+    box-shadow: none;
+  }
+
+  .wizard-panes .output {
+    min-height: 24rem;
+    margin-top: 0.75rem;
+  }
 }
 
 .header {

--- a/packages/ui/src/common/styles/shared.css
+++ b/packages/ui/src/common/styles/shared.css
@@ -118,8 +118,7 @@
   }
 
   .action .action-button {
-    padding: 6px 10px;
-    font-size: 13px;
+    padding: 7px 12px;
   }
 
   .wizard-panes .output {

--- a/packages/ui/src/confidential/App.svelte
+++ b/packages/ui/src/confidential/App.svelte
@@ -27,6 +27,7 @@
   import type { AiFunctionCall } from '../../api/ai-assistant/types/assistant';
   import ErrorDisabledActionButtons from '../common/ErrorDisabledActionButtons.svelte';
   import { createWiz, mergeAiAssistanceOptions } from '../common/Wiz.svelte';
+  import { scrollFade } from '../common/scroll-fade';
 
   const dispatch = createEventDispatcher();
 
@@ -217,16 +218,16 @@
     {/if}
   </div>
 
-  <div class="flex flex-row grow">
+  <div class="wizard-panes flex flex-row grow" use:scrollFade={tab}>
     <div
-      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between h-[calc(100vh-84px)] overflow-auto resize-x"
+      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between overflow-auto resize-x"
     >
       <div class:hidden={tab !== 'ERC7984'}>
         <ERC7984Controls bind:opts={allOpts.ERC7984} errors={errors.ERC7984} />
       </div>
     </div>
 
-    <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)] relative">
+    <div class="output rounded-r-3xl flex flex-col grow overflow-auto relative">
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
           <code class="hljs -solidity grow overflow-auto p-4 {hasErrors ? 'no-select' : ''}"
@@ -241,7 +242,7 @@
 <style lang="postcss">
   .container {
     background-color: var(--gray-1);
-    min-width: 32rem;
+    min-width: 0;
   }
 
   .header {

--- a/packages/ui/src/embed.ts
+++ b/packages/ui/src/embed.ts
@@ -16,11 +16,15 @@ const fallbackChromeHeight = 206;
 const mobileMediaQuery = window.matchMedia('(max-width: 720px)');
 
 function measureChromeHeight(): number {
+  // .nav-row is wizard-page chrome. Without it we are on a host page (docs)
+  // and must not pick up that page's .banner / .header.
+  const navRow = document.querySelector<HTMLElement>('.nav-row');
+  if (!navRow) {
+    return fallbackChromeHeight;
+  }
   const header = document.querySelector<HTMLElement>('.header.container');
   const banner = document.querySelector<HTMLElement>('.banner');
-  const navRow = document.querySelector<HTMLElement>('.nav-row');
-  const height = (header?.offsetHeight ?? 0) + (banner?.offsetHeight ?? 0) + (navRow?.offsetHeight ?? 0);
-  return height > 0 ? height : fallbackChromeHeight;
+  return (header?.offsetHeight ?? 0) + (banner?.offsetHeight ?? 0) + navRow.offsetHeight;
 }
 
 function applyIframeHeight(iframe: HTMLIFrameElement, contentHeight?: number) {
@@ -28,7 +32,7 @@ function applyIframeHeight(iframe: HTMLIFrameElement, contentHeight?: number) {
     iframe.style.height = unsupportedVersionFrameHeight;
     return;
   }
-  if (mobileMediaQuery.matches && contentHeight !== undefined) {
+  if (mobileMediaQuery.matches && contentHeight !== undefined && Number.isFinite(contentHeight) && contentHeight > 0) {
     iframe.style.height = `${Math.ceil(contentHeight)}px`;
     return;
   }

--- a/packages/ui/src/embed.ts
+++ b/packages/ui/src/embed.ts
@@ -7,11 +7,39 @@ if (!document.currentScript || !('src' in document.currentScript)) {
 const currentScript = new URL(document.currentScript.src);
 
 const iframes = new WeakMap<MessageEventSource, HTMLIFrameElement>();
+const mountedIframes = new Set<HTMLIFrameElement>();
+const contentHeights = new WeakMap<HTMLIFrameElement, number>();
 
 let unsupportedVersion: boolean = false;
 const unsupportedVersionFrameHeight = 'auto';
+const fallbackChromeHeight = 206;
+const mobileMediaQuery = window.matchMedia('(max-width: 720px)');
 
-const iframeHeightDiff = '206px';
+function measureChromeHeight(): number {
+  const header = document.querySelector<HTMLElement>('.header.container');
+  const banner = document.querySelector<HTMLElement>('.banner');
+  const navRow = document.querySelector<HTMLElement>('.nav-row');
+  const height = (header?.offsetHeight ?? 0) + (banner?.offsetHeight ?? 0) + (navRow?.offsetHeight ?? 0);
+  return height > 0 ? height : fallbackChromeHeight;
+}
+
+function applyIframeHeight(iframe: HTMLIFrameElement, contentHeight?: number) {
+  if (unsupportedVersion) {
+    iframe.style.height = unsupportedVersionFrameHeight;
+    return;
+  }
+  if (mobileMediaQuery.matches && contentHeight !== undefined) {
+    iframe.style.height = `${Math.ceil(contentHeight)}px`;
+    return;
+  }
+  iframe.style.height = `calc(100vh - ${measureChromeHeight()}px)`;
+}
+
+function syncIframeHeights() {
+  for (const iframe of mountedIframes) {
+    applyIframeHeight(iframe, contentHeights.get(iframe));
+  }
+}
 
 window.addEventListener('message', function (e: MessageEvent<Message>) {
   if (e.source) {
@@ -19,16 +47,20 @@ window.addEventListener('message', function (e: MessageEvent<Message>) {
       unsupportedVersion = true;
       const iframe = iframes.get(e.source);
       if (iframe) {
-        iframe.style.height = unsupportedVersionFrameHeight;
+        applyIframeHeight(iframe);
       }
     } else if (e.data.kind === 'oz-wizard-resize') {
       const iframe = iframes.get(e.source);
       if (iframe) {
-        iframe.style.height = unsupportedVersion ? unsupportedVersionFrameHeight : `calc(100vh - ${iframeHeightDiff})`;
+        contentHeights.set(iframe, e.data.height);
+        applyIframeHeight(iframe, e.data.height);
       }
     }
   }
 });
+
+window.addEventListener('resize', syncIframeHeights);
+mobileMediaQuery.addEventListener('change', syncIframeHeights);
 
 onDOMContentLoaded(function () {
   const wizards = document.querySelectorAll<HTMLElement>('oz-wizard');
@@ -62,10 +94,11 @@ onDOMContentLoaded(function () {
     iframe.style.display = 'block';
     iframe.style.border = '0';
     iframe.style.width = '100%';
-    iframe.style.height = `calc(100vh - ${iframeHeightDiff} )`;
     iframe.allow = 'clipboard-write';
+    applyIframeHeight(iframe);
 
     w.appendChild(iframe);
+    mountedIframes.add(iframe);
 
     if (iframe.contentWindow !== null) {
       iframes.set(iframe.contentWindow, iframe);

--- a/packages/ui/src/embed.ts
+++ b/packages/ui/src/embed.ts
@@ -9,8 +9,8 @@ const currentScript = new URL(document.currentScript.src);
 const iframes = new WeakMap<MessageEventSource, HTMLIFrameElement>();
 const mountedIframes = new Set<HTMLIFrameElement>();
 const contentHeights = new WeakMap<HTMLIFrameElement, number>();
+const unsupportedVersionIframes = new WeakSet<HTMLIFrameElement>();
 
-let unsupportedVersion: boolean = false;
 const unsupportedVersionFrameHeight = 'auto';
 const fallbackChromeHeight = 206;
 const mobileMediaQuery = window.matchMedia('(max-width: 720px)');
@@ -24,7 +24,7 @@ function measureChromeHeight(): number {
 }
 
 function applyIframeHeight(iframe: HTMLIFrameElement, contentHeight?: number) {
-  if (unsupportedVersion) {
+  if (unsupportedVersionIframes.has(iframe)) {
     iframe.style.height = unsupportedVersionFrameHeight;
     return;
   }
@@ -44,9 +44,9 @@ function syncIframeHeights() {
 window.addEventListener('message', function (e: MessageEvent<Message>) {
   if (e.source) {
     if (e.data.kind === 'oz-wizard-unsupported-version') {
-      unsupportedVersion = true;
       const iframe = iframes.get(e.source);
       if (iframe) {
+        unsupportedVersionIframes.add(iframe);
         applyIframeHeight(iframe);
       }
     } else if (e.data.kind === 'oz-wizard-resize') {

--- a/packages/ui/src/solidity/App.svelte
+++ b/packages/ui/src/solidity/App.svelte
@@ -43,6 +43,7 @@
   import ErrorDisabledActionButtons from '../common/ErrorDisabledActionButtons.svelte';
   import { createWiz, mergeAiAssistanceOptions } from '../common/Wiz.svelte';
   import type { Language } from '../common/languages-types';
+  import { scrollFade } from '../common/scroll-fade';
 
   const dispatch = createEventDispatcher();
 
@@ -405,9 +406,9 @@
     {/if}
   </div>
 
-  <div class="flex flex-row grow">
+  <div class="wizard-panes flex flex-row grow" use:scrollFade={tab}>
     <div
-      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between h-[calc(100vh-84px)] overflow-auto resize-x"
+      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between overflow-auto resize-x"
     >
       <div class:hidden={tab !== 'ERC20'}>
         <ERC20Controls
@@ -460,7 +461,7 @@
       </div>
     </div>
 
-    <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)] relative">
+    <div class="output rounded-r-3xl flex flex-col grow overflow-auto relative">
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
           <code class="hljs -solidity grow overflow-auto p-4 {hasErrors ? 'no-select' : ''}"

--- a/packages/ui/src/standalone.css
+++ b/packages/ui/src/standalone.css
@@ -71,7 +71,7 @@ body {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  border-radius: 5rem;
+  border-radius: 1.5rem;
   width: fit-content;
   max-width: 100%;
   min-width: 0;
@@ -266,16 +266,14 @@ body {
     margin: 0.5rem 0 0;
   }
 
+  .nav-row:not(:has(.ui-builder-cta)) .nav {
+    margin-bottom: 0.75rem;
+  }
+
   .ui-builder-cta {
     flex-wrap: wrap;
     gap: 0.5rem;
     margin: 0.75rem 0 0.5rem;
-  }
-
-  .nav .switch {
-    padding: 0.35rem 0.55rem;
-    margin: 0.25rem;
-    font-size: 13px;
   }
 }
 

--- a/packages/ui/src/standalone.css
+++ b/packages/ui/src/standalone.css
@@ -6,6 +6,7 @@ body {
   margin: 0;
   line-height: 1.8;
   box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 @font-face {
@@ -26,7 +27,9 @@ body {
   background: white;
   display: flex;
   flex-direction: row;
-  min-width: 800px;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
   border-bottom: 1px #eaeaea solid;
 }
 
@@ -49,17 +52,14 @@ body {
   font-family: 'inter', Arial, Helvetica, sans-serif;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   min-height: 36px;
   justify-content: center;
   align-items: center;
   background-color: #f5f6ff;
-  min-width: 800px;
-}
-
-@media (min-width: 800px) {
-  .banner {
-    box-sizing: border-box;
-  }
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 /* Navigation */
@@ -70,8 +70,16 @@ body {
   background: var(--gray-1);
   display: flex;
   flex-direction: row;
+  flex-wrap: nowrap;
   border-radius: 5rem;
-  width: fit-content;
+  width: auto;
+  max-width: fit-content;
+  min-width: 0;
+  flex: 1 1 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
 }
 
 .nav img {
@@ -96,6 +104,7 @@ body {
   margin: 0.5rem;
   white-space: nowrap;
   transition: background-color ease-in-out 0.3s;
+  flex-shrink: 0;
 }
 
 .nav .switch:hover {
@@ -174,11 +183,37 @@ body {
 
 .nav-row {
   padding: 0 1rem 0;
-  max-width: 100%;
-  margin: 0 auto 0;
-  min-width: 800px;
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
   max-width: 1500px;
   margin: auto;
+  gap: 0.75rem;
+  flex-wrap: nowrap;
+}
+
+.ui-builder-cta {
+  flex: 0 0 auto;
+  align-items: center;
+  min-width: 0;
+}
+
+.ui-builder-copy {
+  flex: 0 0 auto;
+}
+
+.ui-builder-copy,
+.ui-builder-copy > div {
+  white-space: nowrap;
+}
+
+.nav::-webkit-scrollbar {
+  height: 4px;
+}
+
+.nav::-webkit-scrollbar-thumb {
+  background: var(--gray-3);
+  border-radius: 4px;
 }
 
 .arrow-gray {
@@ -193,13 +228,73 @@ body {
 /* Wizard */
 .wizard-container {
   padding: 0 1rem 0;
+  box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
   margin: 0 auto 0;
 }
 .wizard {
-  min-width: 800px;
+  min-width: 0;
+  width: 100%;
   max-width: 1500px;
   margin: auto;
+}
+
+/* Below the desktop max: language pills get a full row (same wrap on every
+   ecosystem). The UI Builder CTA drops under it as a complete unit — copy,
+   arrow, and button stay visible. */
+@media (max-width: 1440px) {
+  .nav-row {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    align-items: center;
+  }
+
+  .nav {
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+    overflow-x: visible;
+    width: 100%;
+    max-width: 100%;
+    border-radius: 1.25rem;
+  }
+
+  .ui-builder-cta {
+    flex: 1 1 100%;
+    justify-content: flex-end;
+    margin: 0 0 0.5rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .header {
+    padding: 12px 16px;
+  }
+
+  .header .link {
+    margin-right: 12px;
+  }
+
+  .banner {
+    padding: 8px 16px;
+    min-height: 0;
+  }
+
+  .nav {
+    margin: 0.5rem 0 0;
+  }
+
+  .ui-builder-cta {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0.25rem 0 0.5rem;
+  }
+
+  .nav .switch {
+    padding: 0.35rem 0.55rem;
+    margin: 0.25rem;
+    font-size: 13px;
+  }
 }
 
 /* Footer */

--- a/packages/ui/src/standalone.css
+++ b/packages/ui/src/standalone.css
@@ -186,7 +186,8 @@ body {
   /* 1500px content + 1rem padding each side, so the pills line up with .wizard */
   max-width: calc(1500px + 2rem);
   margin: auto;
-  gap: 0.75rem;
+  column-gap: 0.75rem;
+  row-gap: 0;
   flex-wrap: wrap;
 }
 

--- a/packages/ui/src/standalone.css
+++ b/packages/ui/src/standalone.css
@@ -269,7 +269,7 @@ body {
   .ui-builder-cta {
     flex-wrap: wrap;
     gap: 0.5rem;
-    margin: 0.25rem 0 0.5rem;
+    margin: 0.75rem 0 0.5rem;
   }
 
   .nav .switch {

--- a/packages/ui/src/standalone.css
+++ b/packages/ui/src/standalone.css
@@ -70,16 +70,13 @@ body {
   background: var(--gray-1);
   display: flex;
   flex-direction: row;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   border-radius: 5rem;
-  width: auto;
-  max-width: fit-content;
+  width: fit-content;
+  max-width: 100%;
   min-width: 0;
-  flex: 1 1 0;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scrollbar-width: thin;
-  -webkit-overflow-scrolling: touch;
+  flex: 0 1 auto;
+  overflow: visible;
 }
 
 .nav img {
@@ -186,16 +183,19 @@ body {
   box-sizing: border-box;
   width: 100%;
   min-width: 0;
-  max-width: 1500px;
+  /* 1500px content + 1rem padding each side, so the pills line up with .wizard */
+  max-width: calc(1500px + 2rem);
   margin: auto;
   gap: 0.75rem;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 
 .ui-builder-cta {
   flex: 0 0 auto;
   align-items: center;
   min-width: 0;
+  margin-left: auto;
+  margin-bottom: 0.5rem;
 }
 
 .ui-builder-copy {
@@ -205,15 +205,6 @@ body {
 .ui-builder-copy,
 .ui-builder-copy > div {
   white-space: nowrap;
-}
-
-.nav::-webkit-scrollbar {
-  height: 4px;
-}
-
-.nav::-webkit-scrollbar-thumb {
-  background: var(--gray-3);
-  border-radius: 4px;
 }
 
 .arrow-gray {
@@ -245,18 +236,8 @@ body {
    arrow, and button stay visible. */
 @media (max-width: 1440px) {
   .nav-row {
-    flex-wrap: wrap;
     justify-content: flex-start;
     align-items: center;
-  }
-
-  .nav {
-    flex: 1 1 100%;
-    flex-wrap: wrap;
-    overflow-x: visible;
-    width: 100%;
-    max-width: 100%;
-    border-radius: 1.25rem;
   }
 
   .ui-builder-cta {

--- a/packages/ui/src/stellar/App.svelte
+++ b/packages/ui/src/stellar/App.svelte
@@ -37,6 +37,7 @@
   import ZipIcon from '../common/icons/ZipIcon.svelte';
   import type { GenericOptions } from '@openzeppelin/wizard-stellar/src';
   import type { Language } from '../common/languages-types';
+  import { scrollFade } from '../common/scroll-fade';
 
   const WizStellar = createWiz<'stellar'>();
 
@@ -258,9 +259,9 @@
     {/if}
   </div>
 
-  <div class="flex flex-row grow">
+  <div class="wizard-panes flex flex-row grow" use:scrollFade={tab}>
     <div
-      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between h-[calc(100vh-84px)] overflow-auto resize-x"
+      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between overflow-auto resize-x"
     >
       <div class:hidden={tab !== 'Fungible'}>
         <FungibleControls bind:opts={allOpts.Fungible} errors={errors.Fungible} />
@@ -281,7 +282,7 @@
         <AccountControls bind:opts={allOpts.Account} errors={errors.Account} />
       </div>
     </div>
-    <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)]">
+    <div class="output rounded-r-3xl flex flex-col grow overflow-auto">
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
           <code class="hljs -stellar grow overflow-auto p-4">{@html highlightedCode}</code>

--- a/packages/ui/src/stylus/App.svelte
+++ b/packages/ui/src/stylus/App.svelte
@@ -29,6 +29,7 @@
   import type { InitialOptions } from '../common/initial-options';
   import { createWiz, mergeAiAssistanceOptions } from '../common/Wiz.svelte';
   import type { AiFunctionCall } from '../../api/ai-assistant/types/assistant';
+  import { scrollFade } from '../common/scroll-fade';
 
   const dispatch = createEventDispatcher();
 
@@ -171,9 +172,9 @@
     {/if}
   </div>
 
-  <div class="flex flex-row grow">
+  <div class="wizard-panes flex flex-row grow" use:scrollFade={tab}>
     <div
-      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between h-[calc(100vh-84px)] overflow-auto resize-x"
+      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between overflow-auto resize-x"
     >
       <div class:hidden={tab !== 'ERC20'}>
         <ERC20Controls bind:opts={allOpts.ERC20} errors={errors.ERC20} />
@@ -185,7 +186,7 @@
         <ERC1155Controls bind:opts={allOpts.ERC1155} errors={errors.ERC1155} />
       </div>
     </div>
-    <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)]">
+    <div class="output rounded-r-3xl flex flex-col grow overflow-auto">
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
           <code class="hljs -stylus grow overflow-auto p-4">{@html highlightedCode}</code>

--- a/packages/ui/src/uniswap-hooks/App.svelte
+++ b/packages/ui/src/uniswap-hooks/App.svelte
@@ -27,6 +27,7 @@
   import { remixURL } from '../solidity/remix';
   import { createWiz, mergeAiAssistanceOptions } from '../common/Wiz.svelte';
   import type { AiFunctionCall } from '../../api/ai-assistant/types/assistant';
+  import { scrollFade } from '../common/scroll-fade';
 
   import { saveAs } from 'file-saver';
   import { injectHyperlinks } from './inject-hyperlinks';
@@ -226,16 +227,16 @@
     {/if}
   </div>
 
-  <div class="flex flex-row grow">
+  <div class="wizard-panes flex flex-row grow" use:scrollFade={tab}>
     <div
-      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between h-[calc(100vh-84px)] overflow-auto resize-x"
+      class="controls rounded-l-3xl min-w-72 w-72 max-w-[calc(100vw-420px)] flex flex-col shrink-0 justify-between overflow-auto resize-x"
     >
       <div class:hidden={tab !== 'Hooks'}>
         <HooksControls bind:opts={allOpts.Hooks} errors={errors[tab]} />
       </div>
     </div>
 
-    <div class="output rounded-r-3xl flex flex-col grow overflow-auto h-[calc(100vh-84px)] relative">
+    <div class="output rounded-r-3xl flex flex-col grow overflow-auto relative">
       <pre class="flex flex-col grow basis-0 overflow-auto">
         {#if showCode}
           <code class="hljs -solidity grow overflow-auto p-4 {hasErrors ? 'no-select' : ''}"
@@ -250,7 +251,7 @@
 <style lang="postcss">
   .container {
     background-color: var(--gray-1);
-    min-width: 32rem;
+    min-width: 0;
   }
 
   .header {


### PR DESCRIPTION
**Summary**
- Small and mid-size windows no longer force a wide desktop layout or a horizontal page scroll.
- Language pills wrap instead of overflowing. Below ~1440px the UI Builder CTA sits on its own row (copy + button stay visible).
- The options pane scrolls, with a bottom fade that clears at the end of the list.
- On phones, options sit above the code, and Copy / Remix / Download sit on the code card.

Large-screen side-by-side layout is unchanged.